### PR TITLE
deployment: update build/release to publish to drafts correctly

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,8 @@
 name: Publish
 
 on:   
-  release:
-    types:
-      - created
+  push:
+    branches: ['master']
 
 jobs:
   publish:
@@ -26,10 +25,6 @@ jobs:
         run: |
           yarn install
 
-      - name: Download pomerium-cli artifacts
-        run: |
-          yarn download
-
       - name: Import Apple CSC
         uses: apple-actions/import-codesign-certs@v1
         with: 
@@ -47,6 +42,6 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_KEY_ISSUER: ${{ secrets.APPLE_ID_KEY_ISSUER }}
         run: |
-          yarn package -ml --arm64 --x64 --publish always
-          yarn package -w --publish always
+          yarn release -ml --arm64 --x64
+          yarn release -w
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "rebuild": "electron-rebuild --parallel --types prod,dev,optional --module-dir src",
     "lint": "cross-env NODE_ENV=development eslint . --cache --ext .js,.jsx,.ts,.tsx",
     "package": "yarn build && electron-builder build --publish never",
+    "release": "yarn build && electron-builder build",
     "postinstall": "node -r @babel/register .erb/scripts/CheckNativeDep.js && electron-builder install-app-deps && yarn cross-env NODE_ENV=development webpack --config ./.erb/configs/webpack.config.renderer.dev.dll.babel.js && yarn-deduplicate yarn.lock",
     "start": "node -r @babel/register ./.erb/scripts/CheckPortInUse.js && cross-env yarn start:renderer",
     "start:main": "cross-env NODE_ENV=development electron -r ./.erb/scripts/BabelRegister ./src/main.dev.ts",


### PR DESCRIPTION
Some settings in the `package.json` were hard coded to prevent publishing.  

This PR changes the build pipeline and `package.json` scripts to build upon merging to master and update artifacts for a release matching the current `app/package.json` version, IF it is still draft state.

Implicitly this means publishing new releases is done as follows:

1. Create draft GH release of name v${nextVersion}
2. Create/merge PR to bump `app/package.json` version to ${nextVersion}
3. Continue merging until release is in a good state
4. Mark release as published to stop accepting artifact updates
5. Repeat 1/2 when ready to start building RCs for next release