### PR TITLE
Update Tooltip Helper Text

### DIFF
--- a/src/components/FieldWrapper.tsx
+++ b/src/components/FieldWrapper.tsx
@@ -7,7 +7,7 @@ import {
   Container,
   Tooltip,
 } from '@material-ui/core';
-import React, { FC, ReactNode } from 'react';
+import React, { FC, ReactFragment, ReactNode } from 'react';
 import { HelpCircle } from 'react-feather';
 import { Theme } from '../utils/theme';
 
@@ -31,7 +31,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 type FieldWrapperProps = {
   label: string;
-  description: string;
+  description: ReactFragment;
   children: ReactNode;
 };
 

--- a/src/pages/ConnectForm.tsx
+++ b/src/pages/ConnectForm.tsx
@@ -222,7 +222,12 @@ const ConnectForm: FC<Props> = () => {
 
         <FieldWrapper
           description={
-            "OPTIONAL. Pomerium Proxy Url. Useful if the Destination URL isn't publicly resolvable"
+            <>
+              The Pomerium proxy service address. This is required if the{' '}
+              <strong>Destination URL</strong> can&apos;t be resolved from DNS
+              or a local <code>hosts</code> entry, or if the proxy service uses
+              a non-standard port.
+            </>
           }
           label="Alternate Pomerium Url"
         >
@@ -237,7 +242,7 @@ const ConnectForm: FC<Props> = () => {
 
         <FieldWrapper
           label="CA File Path"
-          description="OPTIONAL. If Pomerium is using a CA in your system's trusted keychain you can provide the path to it here."
+          description="OPTIONAL. If Pomerium is using a certificate authority that's not in your system's trusted keychain you can provide the path to it here."
         >
           <TextField
             fullWidth
@@ -250,7 +255,7 @@ const ConnectForm: FC<Props> = () => {
 
         <FieldWrapper
           label="CA File Text"
-          description="OPTIONAL. If Pomerium is using a CA in your system's trusted keychain you can copy/paste it here."
+          description="OPTIONAL. If Pomerium is using a certificate authority that's not in your system's trusted keychain you can copy/paste it here."
         >
           <TextField
             fullWidth

--- a/src/pages/ConnectForm.tsx
+++ b/src/pages/ConnectForm.tsx
@@ -182,8 +182,17 @@ const ConnectForm: FC<Props> = () => {
         </Grid>
 
         <FieldWrapper
-          description="REQUIRED. The url to connect to. The FROM field in a pomerium route."
-          label="Destination Url"
+          description={
+            <>
+              <strong>REQUIRED</strong>
+              <br />
+              The URL to connect to. This should match the <strong>
+                FROM
+              </strong>{' '}
+              field in a pomerium route.
+            </>
+          }
+          label="Destination URL"
         >
           <TextField
             fullWidth
@@ -196,7 +205,13 @@ const ConnectForm: FC<Props> = () => {
         </FieldWrapper>
 
         <FieldWrapper
-          description="Skips TLS verification. No Cert Authority Needed."
+          description={
+            <>
+              <strong>OPTIONAL</strong>
+              <br />
+              Skips TLS verification. No certificate authority Needed.
+            </>
+          }
           label="Disable TLS Verification"
         >
           <Switch
@@ -208,7 +223,16 @@ const ConnectForm: FC<Props> = () => {
         </FieldWrapper>
 
         <FieldWrapper
-          description="OPTIONAL. The port or local address you want to connect to. Ex. :8888 or 127.0.0.1:8888"
+          description={
+            <>
+              <strong>OPTIONAL</strong>
+              <br />
+              The port or local address you want to connect to. Ex.
+              <code>:8888</code> <code>or 127.0.0.1:8888</code>
+              <br />
+              If left blank, a random available port will be used.
+            </>
+          }
           label="Local Address"
         >
           <TextField
@@ -223,13 +247,15 @@ const ConnectForm: FC<Props> = () => {
         <FieldWrapper
           description={
             <>
+              <strong>OPTIONAL</strong>
+              <br />
               The Pomerium proxy service address. This is required if the{' '}
               <strong>Destination URL</strong> can&apos;t be resolved from DNS
               or a local <code>hosts</code> entry, or if the proxy service uses
               a non-standard port.
             </>
           }
-          label="Alternate Pomerium Url"
+          label="Alternate Pomerium URL"
         >
           <TextField
             fullWidth
@@ -242,7 +268,14 @@ const ConnectForm: FC<Props> = () => {
 
         <FieldWrapper
           label="CA File Path"
-          description="OPTIONAL. If Pomerium is using a certificate authority that's not in your system's trusted keychain you can provide the path to it here."
+          description={
+            <>
+              <strong>OPTIONAL</strong>
+              <br />
+              If Pomerium is using a certificate authority that&apos;s not in
+              your trusted keychain, you can provide the path to it here.
+            </>
+          }
         >
           <TextField
             fullWidth
@@ -255,7 +288,14 @@ const ConnectForm: FC<Props> = () => {
 
         <FieldWrapper
           label="CA File Text"
-          description="OPTIONAL. If Pomerium is using a certificate authority that's not in your system's trusted keychain you can copy/paste it here."
+          description={
+            <>
+              <strong>OPTIONAL</strong>
+              <br />
+              If Pomerium is using a certificate authority that&apos;s not in
+              your trusted keychain, you can copy/paste it here.
+            </>
+          }
         >
           <TextField
             fullWidth


### PR DESCRIPTION
This PR updates the tooltip text per feedback in https://github.com/pomerium/internal/issues/575. The updates are also made t the docs [here](https://github.com/pomerium/pomerium/pull/2561/commits/2436c007b6ca50e1ef91bd522fe0fe21cf510222).

This PR also updates the FieldWrapper component to so that the description field is of type ReactFragment, which lets us add text styling (among other things) to the help text. If this is :+1:  I can also style the other descriptions the same way. If not I'll remove it and un-style the description I used it with.