### PR TITLE
move the mac edit menu to be at top level

### DIFF
--- a/src/utils/windowMenu.ts
+++ b/src/utils/windowMenu.ts
@@ -68,27 +68,6 @@ export default class MenuBuilder {
         },
         { type: 'separator' },
         {
-          label: 'Edit',
-          submenu: [
-            { label: 'Undo', accelerator: 'CmdOrCtrl+Z', selector: 'undo:' },
-            {
-              label: 'Redo',
-              accelerator: 'Shift+CmdOrCtrl+Z',
-              selector: 'redo:',
-            },
-            { type: 'separator' },
-            { label: 'Cut', accelerator: 'CmdOrCtrl+X', selector: 'cut:' },
-            { label: 'Copy', accelerator: 'CmdOrCtrl+C', selector: 'copy:' },
-            { label: 'Paste', accelerator: 'CmdOrCtrl+V', selector: 'paste:' },
-            {
-              label: 'Select All',
-              accelerator: 'CmdOrCtrl+A',
-              selector: 'selectAll:',
-            },
-          ],
-        },
-        { type: 'separator' },
-        {
           label: 'Quit',
           accelerator: 'Command+Q',
           click: () => {
@@ -166,9 +145,30 @@ export default class MenuBuilder {
       ],
     };
 
+    const subMenuEdit: DarwinMenuItemConstructorOptions = {
+      label: 'Edit',
+      submenu: [
+        { label: 'Undo', accelerator: 'CmdOrCtrl+Z', selector: 'undo:' },
+        {
+          label: 'Redo',
+          accelerator: 'Shift+CmdOrCtrl+Z',
+          selector: 'redo:',
+        },
+        { type: 'separator' },
+        { label: 'Cut', accelerator: 'CmdOrCtrl+X', selector: 'cut:' },
+        { label: 'Copy', accelerator: 'CmdOrCtrl+C', selector: 'copy:' },
+        { label: 'Paste', accelerator: 'CmdOrCtrl+V', selector: 'paste:' },
+        {
+          label: 'Select All',
+          accelerator: 'CmdOrCtrl+A',
+          selector: 'selectAll:',
+        },
+      ],
+    };
+
     const subMenuView = isDev || prodDebug ? subMenuViewDev : subMenuViewProd;
 
-    return [subMenuAbout, subMenuView, subMenuWindow, subMenuHelp];
+    return [subMenuAbout, subMenuEdit, subMenuView, subMenuWindow, subMenuHelp];
   }
 
   buildDefaultTemplate() {


### PR DESCRIPTION
moves the edit menu on macs to be top level
https://app.zenhub.com/workspaces/pomerium-5f0d1eec340a620025c4dfa0/issues/pomerium/internal/597