### PR TITLE
deployment: embed build metadata

### DIFF
--- a/.erb/scripts/DownloadBinaries.ts
+++ b/.erb/scripts/DownloadBinaries.ts
@@ -7,7 +7,7 @@ const { createGunzip } = require('gunzip-stream');
 const tar = require('tar-stream');
 const unzip = require('unzip-stream');
 
-const pomeriumVersion = 'v0.15.3';
+const { pomeriumCli } = require('../../package.json');
 const pomeriumBuilds: { [char: string]: string[] } = {
   linux: ['amd64', 'arm64'],
   windows: ['amd64'],
@@ -53,7 +53,7 @@ const fetchURL = async (platform: string, arch: string) => {
     'bin',
     saveDetails.binary
   );
-  const url = `https://github.com/pomerium/pomerium/releases/download/${pomeriumVersion}/pomerium-cli-${platform}-${arch}.${saveDetails.format}`;
+  const url = `https://github.com/pomerium/cli/releases/download/${pomeriumCli.version}/pomerium-cli-${platform}-${arch}.${saveDetails.format}`;
 
   console.log(`downloading '${url}' => '${savePath}'`);
 

--- a/.erb/scripts/WriteMetadata.ts
+++ b/.erb/scripts/WriteMetadata.ts
@@ -1,0 +1,15 @@
+import { execSync } from 'child_process';
+import { writeFileSync } from 'fs';
+
+const { pomeriumCli } = require('../../package.json');
+
+const gitHash = execSync('git rev-parse --short HEAD');
+const cliVersion = pomeriumCli.version;
+
+writeFileSync(
+  './src/meta.json',
+  JSON.stringify({
+    gitHash: gitHash.toString().trimRight(),
+    cliVersion: cliVersion,
+  })
+);

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ npm-debug.log.*
 /system_files/**/pomerium-cli.exe
 
 /assets/bin/pomerium-cli
+
+# Transient build time metadata stored here
+src/meta.json

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Cross Platform Desktop Application for establishing TCP connections through Pomerium",
   "scripts": {
     "download": "npx ts-node .erb/scripts/DownloadBinaries.ts",
-    "build": "yarn download && concurrently \"yarn build:main\" \"yarn build:renderer\"",
+    "metadata": "npx ts-node .erb/scripts/WriteMetadata.ts",
+    "build": "concurrently \"yarn download\" \"yarn metadata\"&& concurrently \"yarn build:main\" \"yarn build:renderer\"",
     "build:main": "cross-env NODE_ENV=production webpack --config ./.erb/configs/webpack.config.main.prod.babel.js",
     "build:renderer": "cross-env NODE_ENV=production webpack --config ./.erb/configs/webpack.config.renderer.prod.babel.js",
     "rebuild": "electron-rebuild --parallel --types prod,dev,optional --module-dir src",
@@ -307,5 +308,8 @@
     "hooks": {
       "pre-commit": "lint-staged"
     }
+  },
+  "pomeriumCli": {
+    "version": "v0.0.0-rc1"
   }
 }


### PR DESCRIPTION
Enable embedding build metadata such as `pomerium-cli` version or git commit hash.  Unfortunately there's no particularly direct way to pass this information into an electron-builder application, so this PR places the information into a new `metadata.json` file.  This file can then be referenced by the desktop UI elements similar to `package.json`.

The benefit of using a new file over `package.json` is that we (a) don't have to rewrite an existing file, which feels wrong (b) can avoid accidentally persisting transient changes to `package.json`

Details:

- Centralize upstream `pomerium-cli` version to top level `package.json`
- Add script to generate the new file (`./src/metadata.json`)
- Add new `metadata` command to run said script as a dependency for `yarn build`
- Ensure git ignores `/src/metadata.json`

It should be easy to add other information such as build time.

This will need a minor rebase onto the in-progress UI refactor if it seems like a sane approach.