### PR TITLE
ci: build release artifacts individually

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,9 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_KEY_ISSUER: ${{ secrets.APPLE_ID_KEY_ISSUER }}
         run: |
-          yarn release -ml --arm64 --x64
+          yarn release -m --arm64
+          yarn release -m --x64
+          yarn release -l --arm64
+          yarn release -l --x64
           yarn release -w
 


### PR DESCRIPTION
## Summary

We're getting failures to update the draft release, despite using the recommended [release strategy](https://www.electron.build/configuration/publish#recommended-github-releases-workflow) of electron-builder.  There may be a bug/api limit we're encountering, as we're trying to build/upload 4 mac artifacts and 2 linux artifacts at once.

This change performs the release of each platform/architecture serially, which hopefully sidesteps the problem.  See related issue for more info.

## Related issues

https://github.com/electron-userland/electron-builder/issues/4940

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
