### PR TITLE
include github hash with version

### DIFF
--- a/src/renderer/components/TopTabs.tsx
+++ b/src/renderer/components/TopTabs.tsx
@@ -9,7 +9,7 @@ import {
 } from '@material-ui/core';
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { version } from '../../package.json';
+import { cliVersion, gitHash } from '../../meta.json';
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -37,7 +37,7 @@ const TopTabs = (): JSX.Element => {
           </Grid>
           <Grid item xs={2}>
             <Typography align="center" variant="subtitle2">
-              Version: {version}
+              Version: {cliVersion + ' ' + gitHash}
             </Typography>
           </Grid>
         </Grid>


### PR DESCRIPTION
## Summary
Includes both github has and version in the top right of the app

## Related issues

https://app.zenhub.com/workspaces/pomerium-5f0d1eec340a620025c4dfa0/issues/pomerium/internal/598


## Checklist

- [x] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [x] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
