### PR TITLE
add ability to copy port from list page

### DIFF
--- a/src/renderer/components/ConnectionRow.tsx
+++ b/src/renderer/components/ConnectionRow.tsx
@@ -9,7 +9,7 @@ import {
   capitalize,
 } from '@material-ui/core';
 import { MoreVertical } from 'react-feather';
-import { ipcRenderer } from 'electron';
+import { clipboard, ipcRenderer } from 'electron';
 import { Link } from 'react-router-dom';
 import {
   CONNECT,
@@ -36,12 +36,14 @@ type ConnectionRowProps = {
   folderName: string;
   connection: ListenerRecord;
   connected: boolean;
+  port: string;
 };
 
 const ConnectionRow: React.FC<ConnectionRowProps> = ({
   folderName,
   connection,
   connected,
+  port,
 }: ConnectionRowProps): JSX.Element => {
   const [menuAnchor, setMenuAnchor] = React.useState(null);
 
@@ -74,6 +76,11 @@ const ConnectionRow: React.FC<ConnectionRowProps> = ({
         } = { ...connection };
         delete dupe.id;
         ipcRenderer.send(SAVE_RECORD, dupe);
+        break;
+      case 'copy_port':
+        // eslint-disable-next-line no-case-declarations
+        const parsed = port?.match(/\d+(?![^:]*:)/g);
+        clipboard.writeText(parsed?.length ? parsed[0] : '');
         break;
       default:
         ipcRenderer.send(action, connection?.id || '');
@@ -158,6 +165,14 @@ const ConnectionRow: React.FC<ConnectionRowProps> = ({
             >
               Duplicate
             </MenuItem>
+            {connected && (
+              <MenuItem
+                key="copy_port"
+                onClick={() => handleMenuClick('copy_port')}
+              >
+                Copy Port
+              </MenuItem>
+            )}
             <MenuItem key={EXPORT} onClick={() => handleMenuClick(EXPORT)}>
               Export
             </MenuItem>

--- a/src/renderer/pages/ManageConnections.tsx
+++ b/src/renderer/pages/ManageConnections.tsx
@@ -253,6 +253,7 @@ const ManageConnections = (): JSX.Element => {
                     connected={
                       !!record?.id && statuses[record.id as string]?.listening
                     }
+                    port={statuses[record.id as string]?.listenAddr || ''}
                   />
                 );
               })}
@@ -273,6 +274,7 @@ const ManageConnections = (): JSX.Element => {
                 connected={
                   !!record?.id && statuses[record.id as string]?.listening
                 }
+                port={statuses[record.id as string]?.listenAddr || ''}
               />
             );
           })}
@@ -291,6 +293,7 @@ const ManageConnections = (): JSX.Element => {
                 connected={
                   !!record?.id && statuses[record.id as string]?.listening
                 }
+                port={statuses[record.id as string]?.listenAddr || ''}
               />
             );
           })}


### PR DESCRIPTION
## Summary
Adds a menu item to copy the port of connected listener in the list page


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
