### PR TITLE
show the port in the list of listeners

### DIFF
--- a/src/renderer/components/ConnectionRow.tsx
+++ b/src/renderer/components/ConnectionRow.tsx
@@ -45,6 +45,9 @@ const useStyles = makeStyles(() => ({
   cursor: {
     cursor: 'pointer',
   },
+  spacing: {
+    marginLeft: '5px',
+  },
 }));
 
 const ConnectionRow: React.FC<ConnectionRowProps> = ({
@@ -130,18 +133,28 @@ const ConnectionRow: React.FC<ConnectionRowProps> = ({
         <Grid item xs={4}>
           <Link to={'/view_connection/' + connection?.id || ''} />
         </Grid>
-        <Grid container item xs={3} justifyContent="flex-end">
+        <Grid
+          container
+          item
+          xs={3}
+          justifyContent="flex-end"
+          alignItems="center"
+        >
           {connected && (
-            <Tooltip title="Copy to Clipboard">
-              <Typography
-                variant="subtitle2"
-                onClick={copyAddress}
-                className={classes.cursor}
-              >
-                {'Listening on ' + port + ' '}
-                <Copy size="15" />
-              </Typography>
-            </Tooltip>
+            <>
+              <Tooltip title="Copy to Clipboard">
+                <Typography
+                  variant="subtitle2"
+                  onClick={copyAddress}
+                  className={classes.cursor}
+                >
+                  {'Listening on ' + port}
+                </Typography>
+              </Tooltip>
+              <Tooltip title="Copy to Clipboard" className={classes.spacing}>
+                <Copy size="14" onClick={copyAddress} />
+              </Tooltip>
+            </>
           )}
           {!connected && <Typography variant="subtitle2">Inactive</Typography>}
         </Grid>

--- a/src/renderer/components/ConnectionRow.tsx
+++ b/src/renderer/components/ConnectionRow.tsx
@@ -7,8 +7,9 @@ import {
   MenuItem,
   Menu,
   capitalize,
+  Tooltip,
 } from '@material-ui/core';
-import { MoreVertical } from 'react-feather';
+import { Copy, MoreVertical } from 'react-feather';
 import { clipboard, ipcRenderer } from 'electron';
 import { Link } from 'react-router-dom';
 import {
@@ -78,13 +79,15 @@ const ConnectionRow: React.FC<ConnectionRowProps> = ({
         ipcRenderer.send(SAVE_RECORD, dupe);
         break;
       case 'copy_port':
-        // eslint-disable-next-line no-case-declarations
-        const parsed = port?.match(/\d+(?![^:]*:)/g);
-        clipboard.writeText(parsed?.length ? parsed[0] : '');
+        clipboard.writeText(port);
         break;
       default:
         ipcRenderer.send(action, connection?.id || '');
     }
+  };
+
+  const copyAddress = () => {
+    clipboard.writeText(port);
   };
 
   const toggleConnected = () => {
@@ -101,7 +104,7 @@ const ConnectionRow: React.FC<ConnectionRowProps> = ({
           <IconButton
             key={'menuButton' + folderName}
             aria-label={
-              'toggle connected for ' + folderName + ' ' + connection?.id || ''
+              'toggle listeners for ' + folderName + ' ' + connection?.id || ''
             }
             component="span"
             onClick={toggleConnected}
@@ -114,12 +117,19 @@ const ConnectionRow: React.FC<ConnectionRowProps> = ({
             {capitalize(connection?.conn?.name || '')}
           </Typography>
         </Grid>
-        <Grid item xs={5}>
+        <Grid item xs={4}>
           <Link to={'/view_connection/' + connection?.id || ''} />
         </Grid>
-        <Grid container item xs={2} justifyContent="flex-end">
+        <Grid container item xs={3} justifyContent="flex-end">
           <Typography variant="subtitle2">
-            {connected ? 'Connected' : 'Disconnected'}
+            {connected && (
+              <Tooltip title="Copy to Clipboard">
+                <IconButton onClick={copyAddress}>
+                  <Copy size="20" />
+                </IconButton>
+              </Tooltip>
+            )}
+            {connected ? 'Listening on ' + port : 'Inactive'}
           </Typography>
         </Grid>
         <Grid container item xs={1} justifyContent="center">
@@ -128,7 +138,7 @@ const ConnectionRow: React.FC<ConnectionRowProps> = ({
             aria-haspopup="true"
             onClick={toggleMenu}
             aria-label={
-              'Menu for connection: ' +
+              'Menu for listener: ' +
                 folderName +
                 '-' +
                 connection?.conn?.name || ''

--- a/src/renderer/components/ConnectionRow.tsx
+++ b/src/renderer/components/ConnectionRow.tsx
@@ -138,10 +138,8 @@ const ConnectionRow: React.FC<ConnectionRowProps> = ({
                 onClick={copyAddress}
                 className={classes.cursor}
               >
-                {'Listening on ' + port}
-                <IconButton>
-                  <Copy size="15" />
-                </IconButton>
+                {'Listening on ' + port + ' '}
+                <Copy size="15" />
               </Typography>
             </Tooltip>
           )}

--- a/src/renderer/components/ConnectionRow.tsx
+++ b/src/renderer/components/ConnectionRow.tsx
@@ -8,6 +8,7 @@ import {
   Menu,
   capitalize,
   Tooltip,
+  makeStyles,
 } from '@material-ui/core';
 import { Copy, MoreVertical } from 'react-feather';
 import { clipboard, ipcRenderer } from 'electron';
@@ -40,6 +41,12 @@ type ConnectionRowProps = {
   port: string;
 };
 
+const useStyles = makeStyles(() => ({
+  cursor: {
+    cursor: 'pointer',
+  },
+}));
+
 const ConnectionRow: React.FC<ConnectionRowProps> = ({
   folderName,
   connection,
@@ -47,6 +54,7 @@ const ConnectionRow: React.FC<ConnectionRowProps> = ({
   port,
 }: ConnectionRowProps): JSX.Element => {
   const [menuAnchor, setMenuAnchor] = React.useState(null);
+  const classes = useStyles();
 
   const toggleMenu = (e) => {
     setMenuAnchor(e.currentTarget);
@@ -79,7 +87,9 @@ const ConnectionRow: React.FC<ConnectionRowProps> = ({
         ipcRenderer.send(SAVE_RECORD, dupe);
         break;
       case 'copy_port':
-        clipboard.writeText(port);
+        // eslint-disable-next-line no-case-declarations
+        const parsed = port?.match(/\d+(?![^:]*:)/g);
+        clipboard.writeText(parsed?.length ? parsed[0] : '');
         break;
       default:
         ipcRenderer.send(action, connection?.id || '');
@@ -121,16 +131,21 @@ const ConnectionRow: React.FC<ConnectionRowProps> = ({
           <Link to={'/view_connection/' + connection?.id || ''} />
         </Grid>
         <Grid container item xs={3} justifyContent="flex-end">
-          <Typography variant="subtitle2">
-            {connected && (
-              <Tooltip title="Copy to Clipboard">
-                <IconButton onClick={copyAddress}>
-                  <Copy size="20" />
+          {connected && (
+            <Tooltip title="Copy to Clipboard">
+              <Typography
+                variant="subtitle2"
+                onClick={copyAddress}
+                className={classes.cursor}
+              >
+                {'Listening on ' + port}
+                <IconButton>
+                  <Copy size="15" />
                 </IconButton>
-              </Tooltip>
-            )}
-            {connected ? 'Listening on ' + port : 'Inactive'}
-          </Typography>
+              </Typography>
+            </Tooltip>
+          )}
+          {!connected && <Typography variant="subtitle2">Inactive</Typography>}
         </Grid>
         <Grid container item xs={1} justifyContent="center">
           <IconButton

--- a/src/renderer/components/TagFolderRow.tsx
+++ b/src/renderer/components/TagFolderRow.tsx
@@ -81,7 +81,7 @@ const TagFolderRow: React.FC<FolderProps> = ({
         <Grid item xs={1}>
           <IconButton
             key={'menuButton' + folderName}
-            aria-label={'toggle connections for ' + folderName}
+            aria-label={'toggle listeners for ' + folderName}
             component="span"
             onClick={toggleOpen}
           >
@@ -94,7 +94,7 @@ const TagFolderRow: React.FC<FolderProps> = ({
         <Grid item xs={5} />
         <Grid container item xs={2} justifyContent="flex-end">
           <Typography variant="subtitle2">
-            {connectedListeners} of {totalListeners} connected
+            {connectedListeners} of {totalListeners} listening
           </Typography>
         </Grid>
         <Grid container item xs={1} justifyContent="center">

--- a/src/renderer/components/VirtualFolderRow.tsx
+++ b/src/renderer/components/VirtualFolderRow.tsx
@@ -28,7 +28,7 @@ const VirtualFolderRow: React.FC<VirtualFolderProps> = ({
         <Grid item xs={1}>
           <IconButton
             key={'menuButton' + folderName}
-            aria-label={'toggle connections for ' + folderName}
+            aria-label={'toggle listeners for ' + folderName}
             component="span"
             onClick={toggleOpen}
           >
@@ -41,7 +41,7 @@ const VirtualFolderRow: React.FC<VirtualFolderProps> = ({
         <Grid item xs={5} />
         <Grid container item xs={2} justifyContent="flex-end">
           <Typography variant="subtitle2">
-            {connectedListeners} of {totalListeners} connected
+            {connectedListeners} of {totalListeners} listening
           </Typography>
         </Grid>
         <Grid item xs={1} />


### PR DESCRIPTION
## Summary
![centered](https://user-images.githubusercontent.com/7316885/145637074-8e8df79c-e4db-4345-aef0-828f1c71f0ec.png)




Put the icon on the left so that the text would stay aligned with other rows

## Related issues

Fixes #56 



## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
