### PR TITLE
add opinionated dev setup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,30 @@
 yarn
 ```
 
+## Development checkout of pomerium-cli
+
+### Set up repo clone and symlink
+
+```bash
+yarn dev-setup
+```
+
+This will internally check out the default branch of `pomerium/cli`
+
+### Change branch/tag/commit for cli checkout
+
+```bash
+( cd cli && git checkout [commit-ish] )
+```
+
+### Pull branch updates (if any) and rebuild cli
+
+To fetch branch updates and rebuild the cli binary
+
+```bash
+yarn build-cli
+```
+
 ## Run a dev build
 
 Start the app in the `dev` environment:

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "Cross Platform Desktop Application for establishing TCP connections through Pomerium",
   "scripts": {
     "download": "npx ts-node .erb/scripts/DownloadBinaries.ts",
+    "dev-setup": "git clone https://github.com/pomerium/cli && ln -s $(pwd)/cli/bin/pomerium-cli assets/bin/ && cd cli && make build",
+    "build-cli": "cd cli && git pull origin; make build",
     "metadata": "npx ts-node .erb/scripts/WriteMetadata.ts",
     "build": "concurrently \"yarn download\" \"yarn metadata\"&& concurrently \"yarn build:main\" \"yarn build:renderer\"",
     "build:main": "cross-env NODE_ENV=production webpack --config ./.erb/configs/webpack.config.main.prod.babel.js",


### PR DESCRIPTION
## Summary

The desktop client depends on the [cli binary](https://github.com/pomerium/cli) but may need development against an unreleased branch, commit, etc.

This PR adds a few yarn scripts to set up a checkout of the cli repo and maintain a build of the cli that `yarn start` will pick up during local development.

If we started persisting artifacts from every commit that lands on `main` in the cli repo, we could pull those by default.  However, that wouldn't help in the case of an active PR or branch.  Putting together some commands to easily build locally seemed like a good compromise that would address broader use cases.

## Related issues

n/a


## Checklist

- [ ] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
