### PR TITLE
adds highlights and toast when copying port/address

### DIFF
--- a/src/renderer/components/ConnectionRow.tsx
+++ b/src/renderer/components/ConnectionRow.tsx
@@ -39,11 +39,15 @@ type ConnectionRowProps = {
   connection: ListenerRecord;
   connected: boolean;
   port: string;
+  setAddressCopied: (state: boolean) => void;
 };
 
 const useStyles = makeStyles(() => ({
   cursor: {
     cursor: 'pointer',
+    '&:hover': {
+      color: '#6E43E8',
+    },
   },
   spacing: {
     marginLeft: '5px',
@@ -55,6 +59,7 @@ const ConnectionRow: React.FC<ConnectionRowProps> = ({
   connection,
   connected,
   port,
+  setAddressCopied,
 }: ConnectionRowProps): JSX.Element => {
   const [menuAnchor, setMenuAnchor] = React.useState(null);
   const classes = useStyles();
@@ -93,6 +98,7 @@ const ConnectionRow: React.FC<ConnectionRowProps> = ({
         // eslint-disable-next-line no-case-declarations
         const parsed = port?.match(/\d+(?![^:]*:)/g);
         clipboard.writeText(parsed?.length ? parsed[0] : '');
+        setAddressCopied(true);
         break;
       default:
         ipcRenderer.send(action, connection?.id || '');
@@ -101,6 +107,7 @@ const ConnectionRow: React.FC<ConnectionRowProps> = ({
 
   const copyAddress = () => {
     clipboard.writeText(port);
+    setAddressCopied(true);
   };
 
   const toggleConnected = () => {
@@ -152,7 +159,11 @@ const ConnectionRow: React.FC<ConnectionRowProps> = ({
                 </Typography>
               </Tooltip>
               <Tooltip title="Copy to Clipboard" className={classes.spacing}>
-                <Copy size="14" onClick={copyAddress} />
+                <Copy
+                  size="14"
+                  onClick={copyAddress}
+                  className={classes.cursor}
+                />
               </Tooltip>
             </>
           )}

--- a/src/renderer/components/Toast.tsx
+++ b/src/renderer/components/Toast.tsx
@@ -3,6 +3,7 @@ import { Box, Collapse, IconButton } from '@material-ui/core';
 import { Alert, Color } from '@material-ui/lab';
 import { X } from 'react-feather';
 import { useEffect, useRef, useState } from 'react';
+import { TOAST_LENGTH } from '../../shared/constants';
 
 type ToastProps = {
   msg: string;
@@ -20,7 +21,7 @@ const Toast = ({ msg, alertType }: ToastProps) => {
       if (mounted.current) {
         setOpen(false);
       }
-    }, 6000);
+    }, TOAST_LENGTH);
 
     return () => {
       mounted.current = false;

--- a/src/renderer/pages/ManageConnections.tsx
+++ b/src/renderer/pages/ManageConnections.tsx
@@ -56,6 +56,7 @@ const ManageConnections = (): JSX.Element => {
   const [statuses, setStatuses] = useState<Record<string, ListenerStatus>>({});
   const [error, setError] = useState<ServiceError | null>(null);
   const [uploadSuccess, setUploadSuccess] = useState(false);
+  const [addressCopied, setAddressCopied] = useState(false);
 
   const getConnectedCount = (conns: ListenerRecord[]) => {
     return (
@@ -70,6 +71,12 @@ const ManageConnections = (): JSX.Element => {
       setTimeout(() => setUploadSuccess(false), 1100);
     }
   }, [uploadSuccess]);
+
+  useEffect(() => {
+    if (addressCopied) {
+      setTimeout(() => setAddressCopied(false), 1100);
+    }
+  }, [addressCopied]);
 
   useEffect(() => {
     ipcRenderer.on(GET_UNIQUE_TAGS, (_, args) => {
@@ -221,6 +228,7 @@ const ManageConnections = (): JSX.Element => {
 
       {error && <Toast msg={error.message} alertType="error" />}
       {uploadSuccess && <Toast msg="Upload Successful" alertType="success" />}
+      {addressCopied && <Toast msg="Address Copied" alertType="success" />}
       {Object.values(statuses)
         .filter((status) => !!status.lastError)
         .map((status) => (
@@ -254,6 +262,7 @@ const ManageConnections = (): JSX.Element => {
                       !!record?.id && statuses[record.id as string]?.listening
                     }
                     port={statuses[record.id as string]?.listenAddr || ''}
+                    setAddressCopied={setAddressCopied}
                   />
                 );
               })}
@@ -275,6 +284,7 @@ const ManageConnections = (): JSX.Element => {
                   !!record?.id && statuses[record.id as string]?.listening
                 }
                 port={statuses[record.id as string]?.listenAddr || ''}
+                setAddressCopied={setAddressCopied}
               />
             );
           })}
@@ -294,6 +304,7 @@ const ManageConnections = (): JSX.Element => {
                   !!record?.id && statuses[record.id as string]?.listening
                 }
                 port={statuses[record.id as string]?.listenAddr || ''}
+                setAddressCopied={setAddressCopied}
               />
             );
           })}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -3,6 +3,9 @@ import { Selector } from './pb/api';
 export const isProd = process.env.NODE_ENV === 'production';
 export const isDev = process.env.NODE_ENV === 'development';
 export const prodDebug = process.env.DEBUG_PROD === 'true';
+
+export const TOAST_LENGTH = 6000;
+
 // Actions for the ipcMain and ipcRenderer messages
 export const CONNECTION_RESPONSE = 'connection-resp';
 export const CONNECTION_CLOSED = 'connection-close';


### PR DESCRIPTION
## Summary
Adds highlight and toast when copying port/address

## Related issues
[Fixes 703](https://app.zenhub.com/workspaces/pomerium-5f0d1eec340a620025c4dfa0/issues/pomerium/internal/703)



## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
