### PR TITLE
Bump packaging to v0.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -318,6 +318,6 @@
     }
   },
   "pomeriumCli": {
-    "version": "v0.0.0-rc2"
+    "version": "v0.16.0"
   }
 }

--- a/src/package.json
+++ b/src/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pomerium-desktop",
   "productName": "pomerium-desktop",
-  "version": "0.0.2",
+  "version": "0.16.0",
   "description": "Cross Platform Desktop Application for establishing TCP connections through Pomerium",
   "main": "./main.prod.js",
   "author": {


### PR DESCRIPTION
## Summary

Update package.json for [v0.16](https://github.com/pomerium/pomerium/releases/tag/v0.16.0) release of Pomerium Core.

## Related issues

n/a

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
