### PR TITLE
add a shortcut for Add Connection

### DIFF
--- a/src/main.dev.ts
+++ b/src/main.dev.ts
@@ -141,6 +141,10 @@ app.on('ready', async () => {
       mainWindow?.webContents.send('redirectTo', '/manage');
       mainWindow?.show();
     });
+    globalShortcut.register('CommandOrControl+A', () => {
+      mainWindow?.webContents.send('redirectTo', '/connectForm');
+      mainWindow?.show();
+    });
     menu.tray.on('click', () => {
       menu.tray.popUpContextMenu(trayMenuHelper.createContextMenu());
     });

--- a/src/trayMenu/helper.ts
+++ b/src/trayMenu/helper.ts
@@ -134,8 +134,8 @@ export default class Helper {
     const { appWindow } = this;
     const template: (MenuItemConstructorOptions | MenuItem)[] = [];
     template.push({
-      label: 'Connections',
-      icon: nativeImage.createFromPath(path.join(menuIconPath, 'add.png')),
+      label: 'Add Connection',
+      accelerator: 'CommandOrControl+A',
       click() {
         appWindow?.webContents.send('redirectTo', '/connectForm');
         appWindow?.show();

--- a/src/trayMenu/helper.ts
+++ b/src/trayMenu/helper.ts
@@ -142,6 +142,19 @@ export default class Helper {
       },
     });
 
+    template.push({
+      label: 'Manage Connections',
+      accelerator: 'CommandOrControl+M',
+      click() {
+        appWindow?.webContents.send('redirectTo', '/manage');
+        appWindow?.show();
+      },
+    });
+
+    template.push({
+      type: 'separator',
+    });
+
     this.tags.forEach((tag) => {
       const conns = this.buildFolderSubmenu(
         this.records.filter((rec) => rec.tags.includes(tag))
@@ -152,15 +165,6 @@ export default class Helper {
         icon: nativeImage.createFromPath(path.join(menuIconPath, 'folder.png')),
         submenu: conns,
       });
-    });
-
-    template.push({
-      label: 'Manage Connections',
-      accelerator: 'CommandOrControl+M',
-      click() {
-        appWindow?.webContents.send('redirectTo', '/manage');
-        appWindow?.show();
-      },
     });
 
     template.push({


### PR DESCRIPTION
## Summary
Remove icon adds shortcut for Add Connection page in the System Tray Menu

## Related issues
Fixes https://github.com/pomerium/internal/issues/657


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
