### PR TITLE
show confirmation dialog before deleting all connections by tag

### DIFF
--- a/src/renderer/components/ConfirmationDialog.tsx
+++ b/src/renderer/components/ConfirmationDialog.tsx
@@ -7,6 +7,7 @@ import {
   DialogActions,
   Button,
 } from '@material-ui/core';
+
 export interface ConfirmationDialogProps {
   title: string;
   text: string;

--- a/src/renderer/components/ConfirmationDialog.tsx
+++ b/src/renderer/components/ConfirmationDialog.tsx
@@ -1,0 +1,42 @@
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Button,
+} from '@material-ui/core';
+import React, { FC } from 'react';
+
+export interface ConfirmationDialogProps {
+  title: string;
+  text: string;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+const ConfirmationDialog: FC<ConfirmationDialogProps> = ({
+  title,
+  text,
+  onConfirm,
+  onClose,
+}) => {
+  return (
+    <Dialog open={true} onClose={onClose}>
+      <DialogTitle id="alert-dialog-title">{title}</DialogTitle>
+      <DialogContent>
+        <DialogContentText id="alert-dialog-description">
+          {text}
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={onConfirm} autoFocus>
+          OK
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default ConfirmationDialog;

--- a/src/renderer/components/ConfirmationDialog.tsx
+++ b/src/renderer/components/ConfirmationDialog.tsx
@@ -1,3 +1,4 @@
+import React, { FC } from 'react';
 import {
   Dialog,
   DialogTitle,
@@ -6,8 +7,6 @@ import {
   DialogActions,
   Button,
 } from '@material-ui/core';
-import React, { FC } from 'react';
-
 export interface ConfirmationDialogProps {
   title: string;
   text: string;
@@ -20,23 +19,21 @@ const ConfirmationDialog: FC<ConfirmationDialogProps> = ({
   text,
   onConfirm,
   onClose,
-}) => {
-  return (
-    <Dialog open onClose={onClose}>
-      <DialogTitle id="alert-dialog-title">{title}</DialogTitle>
-      <DialogContent>
-        <DialogContentText id="alert-dialog-description">
-          {text}
-        </DialogContentText>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose}>Cancel</Button>
-        <Button onClick={onConfirm} autoFocus>
-          OK
-        </Button>
-      </DialogActions>
-    </Dialog>
-  );
-};
+}: ConfirmationDialogProps): JSX.Element => (
+  <Dialog open onClose={onClose}>
+    <DialogTitle id="alert-dialog-title">{title}</DialogTitle>
+    <DialogContent>
+      <DialogContentText id="alert-dialog-description">
+        {text}
+      </DialogContentText>
+    </DialogContent>
+    <DialogActions>
+      <Button onClick={onClose}>Cancel</Button>
+      <Button onClick={onConfirm} autoFocus>
+        OK
+      </Button>
+    </DialogActions>
+  </Dialog>
+);
 
 export default ConfirmationDialog;

--- a/src/renderer/components/ConfirmationDialog.tsx
+++ b/src/renderer/components/ConfirmationDialog.tsx
@@ -22,7 +22,7 @@ const ConfirmationDialog: FC<ConfirmationDialogProps> = ({
   onClose,
 }) => {
   return (
-    <Dialog open={true} onClose={onClose}>
+    <Dialog open onClose={onClose}>
       <DialogTitle id="alert-dialog-title">{title}</DialogTitle>
       <DialogContent>
         <DialogContentText id="alert-dialog-description">

--- a/src/renderer/components/TagFolderRow.tsx
+++ b/src/renderer/components/TagFolderRow.tsx
@@ -82,7 +82,14 @@ const TagFolderRow: React.FC<FolderProps> = ({
 
   return (
     <>
-      {confirmation && <ConfirmationDialog {...confirmation} />}
+      {confirmation && (
+        <ConfirmationDialog
+          title={confirmation.title}
+          text={confirmation.text}
+          onConfirm={confirmation.onConfirm}
+          onClose={confirmation.onClose}
+        />
+      )}
       <Grid container>
         <Grid container item xs={12} alignItems="center">
           <Grid item xs={1}>

--- a/src/renderer/components/TagFolderRow.tsx
+++ b/src/renderer/components/TagFolderRow.tsx
@@ -1,12 +1,6 @@
 import * as React from 'react';
 import { PropsWithChildren } from 'react';
 import {
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-  DialogTitle,
   Divider,
   Grid,
   IconButton,

--- a/src/renderer/components/TagFolderRow.tsx
+++ b/src/renderer/components/TagFolderRow.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
 import { PropsWithChildren } from 'react';
 import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
   Divider,
   Grid,
   IconButton,
@@ -21,6 +27,9 @@ import {
 import ClosedFolder from '../icons/ClosedFolder';
 import OpenFolder from '../icons/OpenFolder';
 import { ListenerUpdateRequest, Selector } from '../../shared/pb/api';
+import ConfirmationDialog, {
+  ConfirmationDialogProps,
+} from './ConfirmationDialog';
 
 type FolderProps = {
   folderName: string;
@@ -37,6 +46,8 @@ const TagFolderRow: React.FC<FolderProps> = ({
   children,
 }: PropsWithChildren<FolderProps>): JSX.Element => {
   const [open, setOpen] = React.useState<boolean>(false);
+  const [confirmation, setConfirmation] =
+    React.useState<ConfirmationDialogProps | null>(null);
 
   const toggleOpen = () => {
     setOpen(!open);
@@ -76,74 +87,87 @@ const TagFolderRow: React.FC<FolderProps> = ({
   };
 
   return (
-    <Grid container>
-      <Grid container item xs={12} alignItems="center">
-        <Grid item xs={1}>
-          <IconButton
-            key={'menuButton' + folderName}
-            aria-label={'toggle listeners for ' + folderName}
-            component="span"
-            onClick={toggleOpen}
-          >
-            {open ? <OpenFolder /> : <ClosedFolder />}
-          </IconButton>
-        </Grid>
-        <Grid item xs={3}>
-          <Typography variant="h6">{folderName}</Typography>
-        </Grid>
-        <Grid item xs={5} />
-        <Grid container item xs={2} justifyContent="flex-end">
-          <Typography variant="subtitle2">
-            {connectedListeners} of {totalListeners} listening
-          </Typography>
-        </Grid>
-        <Grid container item xs={1} justifyContent="center">
-          <IconButton
-            aria-controls="folder-menu"
-            aria-haspopup="true"
-            onClick={toggleMenu}
-            aria-label={'Menu for folder: ' + folderName}
-          >
-            <MoreVertical />
-          </IconButton>
-          <Menu
-            id={'folder-menu' + folderName}
-            anchorEl={menuAnchor}
-            keepMounted
-            open={Boolean(menuAnchor)}
-            onClose={handleMenuClose}
-          >
-            <MenuItem
-              key={CONNECT_ALL}
-              onClick={() => handleMenuClick(CONNECT_ALL)}
+    <>
+      {confirmation && <ConfirmationDialog {...confirmation} />}
+      <Grid container>
+        <Grid container item xs={12} alignItems="center">
+          <Grid item xs={1}>
+            <IconButton
+              key={'menuButton' + folderName}
+              aria-label={'toggle listeners for ' + folderName}
+              component="span"
+              onClick={toggleOpen}
             >
-              Connect All
-            </MenuItem>
-            <MenuItem
-              key={DISCONNECT_ALL}
-              onClick={() => handleMenuClick(DISCONNECT_ALL)}
+              {open ? <OpenFolder /> : <ClosedFolder />}
+            </IconButton>
+          </Grid>
+          <Grid item xs={3}>
+            <Typography variant="h6">{folderName}</Typography>
+          </Grid>
+          <Grid item xs={5} />
+          <Grid container item xs={2} justifyContent="flex-end">
+            <Typography variant="subtitle2">
+              {connectedListeners} of {totalListeners} listening
+            </Typography>
+          </Grid>
+          <Grid container item xs={1} justifyContent="center">
+            <IconButton
+              aria-controls="folder-menu"
+              aria-haspopup="true"
+              onClick={toggleMenu}
+              aria-label={'Menu for folder: ' + folderName}
             >
-              Disconnect All
-            </MenuItem>
-            <MenuItem key={EXPORT} onClick={() => handleMenuClick(EXPORT)}>
-              Export
-            </MenuItem>
-            <MenuItem
-              key={DELETE_ALL}
-              onClick={() => handleMenuClick(DELETE_ALL)}
+              <MoreVertical />
+            </IconButton>
+            <Menu
+              id={'folder-menu' + folderName}
+              anchorEl={menuAnchor}
+              keepMounted
+              open={Boolean(menuAnchor)}
+              onClose={handleMenuClose}
             >
-              Delete
-            </MenuItem>
-          </Menu>
+              <MenuItem
+                key={CONNECT_ALL}
+                onClick={() => handleMenuClick(CONNECT_ALL)}
+              >
+                Connect All
+              </MenuItem>
+              <MenuItem
+                key={DISCONNECT_ALL}
+                onClick={() => handleMenuClick(DISCONNECT_ALL)}
+              >
+                Disconnect All
+              </MenuItem>
+              <MenuItem key={EXPORT} onClick={() => handleMenuClick(EXPORT)}>
+                Export
+              </MenuItem>
+              <MenuItem
+                key={DELETE_ALL}
+                onClick={() => {
+                  setConfirmation({
+                    title: 'Delete connections',
+                    text: `All connections with tag ${folderName} will be deleted`,
+                    onClose: () => setConfirmation(null),
+                    onConfirm: () => {
+                      setConfirmation(null);
+                      handleMenuClick(DELETE_ALL);
+                    },
+                  });
+                }}
+              >
+                Delete
+              </MenuItem>
+            </Menu>
+          </Grid>
         </Grid>
+        <Grid container item xs={12}>
+          <Grid item xs={12}>
+            <Divider />
+          </Grid>
+        </Grid>
+        {open && children}
       </Grid>
-      <Grid container item xs={12}>
-        <Grid item xs={12}>
-          <Divider />
-        </Grid>
-      </Grid>
-      {open && children}
-    </Grid>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary

Shows confirmation dialog before connections by tag are deleted. 

![image](https://user-images.githubusercontent.com/673131/148851559-9e35716e-1533-4f53-9b78-17ccc3c555c9.png)

## Related issues

Fixes https://github.com/pomerium/internal/issues/724

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
