### PR TITLE
Update confirmation punctuation.

### DIFF
--- a/src/renderer/components/TagFolderRow.tsx
+++ b/src/renderer/components/TagFolderRow.tsx
@@ -147,7 +147,7 @@ const TagFolderRow: React.FC<FolderProps> = ({
                 onClick={() => {
                   setConfirmation({
                     title: 'Delete connections?',
-                    text: `All connections with tag ${folderName} will be deleted:`,
+                    text: `All connections with tag ${folderName} will be deleted.`,
                     onClose: () => setConfirmation(null),
                     onConfirm: () => {
                       setConfirmation(null);


### PR DESCRIPTION
## Summary

Updates punctuation in folder delete confirmation from `:` to `.` as requested in https://github.com/pomerium/internal/issues/724#issuecomment-1009544781

Resolves https://github.com/pomerium/internal/issues/724

## Checklist

- [x] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
