### PR TITLE
add extra protection in main thread

### DIFF
--- a/src/main.dev.ts
+++ b/src/main.dev.ts
@@ -186,8 +186,10 @@ app.on('ready', async () => {
           err,
           res,
         });
-        trayMenuHelper.setRecord(res);
-        menu.tray.setContextMenu(trayMenuHelper.createContextMenu());
+        if (!err && res) {
+          trayMenuHelper.setRecord(res);
+          menu.tray.setContextMenu(trayMenuHelper.createContextMenu());
+        }
       });
     });
     ipcMain.on(GET_RECORDS, (evt, selector: Selector) => {
@@ -197,14 +199,16 @@ app.on('ready', async () => {
           err,
           res,
         });
-        if (selector.all) {
-          trayMenuHelper.setRecords(res.records);
-        } else {
-          res.records.forEach((rec) => {
-            trayMenuHelper.setRecord(rec);
-          });
+        if (!err && res) {
+          if (selector.all) {
+            trayMenuHelper.setRecords(res.records);
+          } else {
+            res.records.forEach((rec) => {
+              trayMenuHelper.setRecord(rec);
+            });
+          }
+          menu.tray.setContextMenu(trayMenuHelper.createContextMenu());
         }
-        menu.tray.setContextMenu(trayMenuHelper.createContextMenu());
       });
     });
     ipcMain.on(GET_ALL_RECORDS, (evt) => {
@@ -220,8 +224,10 @@ app.on('ready', async () => {
             err,
             res,
           });
-          trayMenuHelper.setRecords(res.records);
-          menu.tray.setContextMenu(trayMenuHelper.createContextMenu());
+          if (!err && res) {
+            trayMenuHelper.setRecords(res.records);
+            menu.tray.setContextMenu(trayMenuHelper.createContextMenu());
+          }
         }
       );
     });
@@ -232,8 +238,10 @@ app.on('ready', async () => {
           err,
           tags: res?.tags || [],
         });
-        trayMenuHelper.setTags(res.tags);
-        menu.tray.setContextMenu(trayMenuHelper.createContextMenu());
+        if (!err && res) {
+          trayMenuHelper.setTags(res.tags);
+          menu.tray.setContextMenu(trayMenuHelper.createContextMenu());
+        }
       });
     });
     ipcMain.on(DELETE, (evt, id: string) => {
@@ -315,8 +323,10 @@ app.on('ready', async () => {
           err,
           res,
         });
-        trayMenuHelper.setStatuses(res.listeners);
-        menu.tray.setContextMenu(trayMenuHelper.createContextMenu());
+        if (!err && res) {
+          trayMenuHelper.setStatuses(res.listeners);
+          menu.tray.setContextMenu(trayMenuHelper.createContextMenu());
+        }
       });
     });
     ipcMain.on(LISTENER_STATUS, (evt, args: Selector) => {
@@ -326,8 +336,10 @@ app.on('ready', async () => {
           err,
           res,
         });
-        trayMenuHelper.setStatuses(res.listeners);
-        menu.tray.setContextMenu(trayMenuHelper.createContextMenu());
+        if (!err && res) {
+          trayMenuHelper.setStatuses(res.listeners);
+          menu.tray.setContextMenu(trayMenuHelper.createContextMenu());
+        }
       });
     });
     ipcMain.on(LISTENER_LOG, (evt, args) => {

--- a/src/renderer/components/TagFolderRow.tsx
+++ b/src/renderer/components/TagFolderRow.tsx
@@ -105,7 +105,9 @@ const TagFolderRow: React.FC<FolderProps> = ({
           <Grid item xs={3} onClick={toggleOpen}>
             <Typography variant="h6">{folderName}</Typography>
           </Grid>
-          <Grid item xs={5} onClick={toggleOpen} />
+          <Grid container item xs={5} onClick={toggleOpen}>
+            &nbsp;
+          </Grid>
           <Grid
             container
             item

--- a/src/renderer/components/VirtualFolderRow.tsx
+++ b/src/renderer/components/VirtualFolderRow.tsx
@@ -38,7 +38,9 @@ const VirtualFolderRow: React.FC<VirtualFolderProps> = ({
         <Grid item xs={3} onClick={toggleOpen}>
           <Typography variant="h6">{folderName}</Typography>
         </Grid>
-        <Grid item xs={5} onClick={toggleOpen} />
+        <Grid container item xs={5} onClick={toggleOpen}>
+          &nbsp;
+        </Grid>
         <Grid
           container
           item


### PR DESCRIPTION
## Summary
Add some extra protection when grpc errors come back. Prevents sentry crashes.
Also fix the row click so it works when you click in the center of the row.

## Related issues
Fixes https://app.zenhub.com/workspaces/pomerium-5f0d1eec340a620025c4dfa0/issues/pomerium/internal/745



## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
