### PR TITLE
hide the dock on macs

### DIFF
--- a/src/main.dev.ts
+++ b/src/main.dev.ts
@@ -168,7 +168,7 @@ app.on('ready', async () => {
     })
   );
 
-  if (process.platform !== 'darwin') {
+  if (process.platform === 'darwin') {
     app.dock.hide();
   }
 

--- a/src/main.dev.ts
+++ b/src/main.dev.ts
@@ -168,6 +168,10 @@ app.on('ready', async () => {
     })
   );
 
+  if (process.platform !== 'darwin') {
+    app.dock.hide();
+  }
+
   const trayMenuHelper = new Helper([], {}, [], mainWindow, null);
   const tray = trayMenuHelper.createTray();
   const menu = menubar({


### PR DESCRIPTION
## Summary
Should remove the pomerium icon from the dock on macs. 
NEEDS TESTING ON A MAC!

## Related issues
Fixes https://github.com/pomerium/desktop-client/issues/99
Fixes https://github.com/pomerium/desktop-client/issues/97



## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
