### PR TITLE
add error check for export

### DIFF
--- a/src/main.dev.ts
+++ b/src/main.dev.ts
@@ -124,13 +124,14 @@ const onUncaughtException = (() => {
       return;
     }
     shuttingDown = true;
-    Sentry.captureException(err);
+    const sentryId = Sentry.captureException(err);
 
     const msg = {
       type: 'error',
       title: 'Error in Main process',
       message:
-        'Something went wrong. Contact your administrator or Pomerium representative.',
+        'If you would like to file a bug report please include the following Sentry Id: ' +
+        sentryId,
     } as Electron.MessageBoxOptions;
 
     if ('spawnargs' in err) {
@@ -285,7 +286,7 @@ app.on('ready', async () => {
         (err, res) => {
           evt?.sender?.send(EXPORT, {
             err,
-            data: res.data,
+            data: res?.data || [],
             filename: args.filename,
           });
         }


### PR DESCRIPTION
## Summary
Fixes bug when error returned from export process res.data is undefined
Adds sentry id to the pop up message.

## Related issues

Fixes [#798](https://github.com/pomerium/internal/issues/798)


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
