### PR TITLE
remove dock from mac

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,10 @@
       "hardenedRuntime": true,
       "entitlements": "system_files/mac/common/entitlements.mac.plist",
       "entitlementsInherit": "system_files/mac/common/entitlements.mac.plist",
-      "gatekeeperAssess": false
+      "gatekeeperAssess": false,
+      "extendInfo": {
+        "LSUIElement": 1
+      }
     },
     "dmg": {
       "sign": false,


### PR DESCRIPTION
## Summary
Removes the dock icon for mac via plist
REQUIRES BUILD, INSTALL, TEST on Mac

## Related issues
Fixes https://github.com/pomerium/desktop-client/issues/99
Fixes https://github.com/pomerium/desktop-client/issues/100


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
