### PR TITLE
notify tap of releases

### DIFF
--- a/.github/workflows/notify-tap.yml
+++ b/.github/workflows/notify-tap.yml
@@ -1,7 +1,5 @@
 on:
   release:
-  push:
-    branches: ["cdoxsey/homebrew"]
 
 jobs:
   notify-tap:

--- a/.github/workflows/notify-tap.yml
+++ b/.github/workflows/notify-tap.yml
@@ -9,11 +9,13 @@ jobs:
 
     steps:
       - id: get_version
-        uses: battila7/get-version-action@v2
+        uses: pozetroninc/github-action-get-latest-release@master
+        with:
+          repository: ${{ github.repository }}
 
       - uses: peter-evans/repository-dispatch@v2
         with:
           repository: pomerium/homebrew-tap
           token: ${{ secrets.APPARITOR_GITHUB_TOKEN }}
           event-type: desktop-client-release
-          client-payload: '{ "version": "${{ steps.get_version.outputs.version-without-v }}" }'
+          client-payload: '{ "version": "${{ steps.get_version.outputs.release }}" }'

--- a/.github/workflows/notify-tap.yml
+++ b/.github/workflows/notify-tap.yml
@@ -16,4 +16,4 @@ jobs:
           repository: pomerium/homebrew-tap
           token: ${{ secrets.APPARITOR_GITHUB_TOKEN }}
           event-type: desktop-client-release
-          client-payload: '{ "version": "${{ steps.get_version.outputs.version }}" }'
+          client-payload: '{ "version": "${{ steps.get_version.outputs.version-without-v }}" }'

--- a/.github/workflows/notify-tap.yml
+++ b/.github/workflows/notify-tap.yml
@@ -1,0 +1,19 @@
+on:
+  release:
+  push:
+    branches: ["cdoxsey/homebrew"]
+
+jobs:
+  notify-tap:
+    runs-on: ubuntu-latest
+
+    steps:
+      - id: get_version
+        uses: battila7/get-version-action@v2
+
+      - uses: peter-evans/repository-dispatch@v2
+        with:
+          repository: pomerium/homebrew-tap
+          token: ${{ secrets.APPARITOR_GITHUB_TOKEN }}
+          event-type: desktop-client-release
+          client-payload: '{ "version": "${{ steps.get_version.outputs.version }}" }'

--- a/.github/workflows/notify-tap.yml
+++ b/.github/workflows/notify-tap.yml
@@ -13,9 +13,15 @@ jobs:
         with:
           repository: ${{ github.repository }}
 
+      - id: clean_version
+        run: |
+          echo "::set-output name=release::${VERSION#v}"
+        env:
+          VERSION: "${{ steps.get_version.outputs.release }}"
+
       - uses: peter-evans/repository-dispatch@v2
         with:
           repository: pomerium/homebrew-tap
           token: ${{ secrets.APPARITOR_GITHUB_TOKEN }}
           event-type: desktop-client-release
-          client-payload: '{ "version": "${{ steps.get_version.outputs.release }}" }'
+          client-payload: '{ "version": "${{ steps.clean_version.outputs.release }}" }'


### PR DESCRIPTION
## Summary
Notify homebrew-tap when there's a release.

## Related issues
Fixes https://github.com/pomerium/desktop-client/issues/117


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
