### PR TITLE
do not auto update for mac until we get approved in store

### DIFF
--- a/src/main.dev.ts
+++ b/src/main.dev.ts
@@ -131,9 +131,11 @@ async function init(): Promise<void> {
   const cliProcess = cli.process;
   const { configClient, listenerClient } = cli;
 
-  // Remove this if your app does not use auto updates
-  // eslint-disable-next-line
-  new AppUpdater();
+  if (process.platform !== 'darwin') {
+    // eslint-disable-next-line
+    new AppUpdater();
+  }
+
   installExtension(REDUX_DEVTOOLS)
     .then((name: string) => console.log(`Added Extension:  ${name}`))
     .catch((err: Error) => console.log('An error occurred: ', err));


### PR DESCRIPTION
## Summary
Remove auto update for macs until we can get approved in store

## Related issues

Fixes [#864](https://github.com/pomerium/internal/issues/864)



## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
