### PR TITLE
fix search bar

### DIFF
--- a/src/renderer/components/TopBar.tsx
+++ b/src/renderer/components/TopBar.tsx
@@ -21,6 +21,11 @@ const TopBar: FC = () => {
   };
 
   const fetch = () => {
+    ipcRenderer.once(GET_ALL_RECORDS, (_e, args) => {
+      if (!args.err) {
+        setConnections(args.res.records);
+      }
+    });
     ipcRenderer.send(GET_ALL_RECORDS);
   };
 
@@ -32,16 +37,7 @@ const TopBar: FC = () => {
   });
 
   useEffect(() => {
-    ipcRenderer.on(GET_ALL_RECORDS, (_e, args) => {
-      if (!args.err) {
-        setConnections(args.res.records);
-      }
-    });
     fetch();
-
-    return function cleanup() {
-      ipcRenderer.removeAllListeners(GET_ALL_RECORDS);
-    };
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
Fixes the call to get all records in the search bar.
It was getting unmounted and so it lost the event listener.
Used a one time event listener now.

## Related issues
Fixes #172 



## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
