### PR TITLE
replace ::set-output in notify-tap action

### DIFF
--- a/.github/workflows/notify-tap.yml
+++ b/.github/workflows/notify-tap.yml
@@ -13,7 +13,7 @@ jobs:
 
       - id: clean_version
         run: |
-          echo "::set-output name=release::${VERSION#v}"
+          echo "release=${VERSION#v}" >> $GITHUB_OUTPUT
         env:
           VERSION: "${{ steps.get_version.outputs.release }}"
 


### PR DESCRIPTION
## Summary

Update the notify-tap.yml GitHub Action workflow to replace the deprecated `::set-output` command with the newer `$GITHUB_OUTPUT` file mechanism.

## Related issues

- https://github.com/pomerium/internal/issues/1511

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
