### PR TITLE
client certificate from system trust store

### DIFF
--- a/api.proto
+++ b/api.proto
@@ -217,4 +217,6 @@ message Connection {
     bytes ca_cert = 6;
   }
   optional Certificate client_cert = 7;
+  // issuer Common Name to use when searching for a client certificate in the system trust store
+  optional string client_cert_issuer_cn = 8;
 }

--- a/src/renderer/pages/ConnectionView.tsx
+++ b/src/renderer/pages/ConnectionView.tsx
@@ -14,6 +14,7 @@ import {
   IconButton,
   Menu,
   MenuItem,
+  Stack,
   Typography,
 } from '@mui/material';
 import { useParams } from 'react-router-dom';
@@ -406,20 +407,33 @@ const ConnectionView = (): JSX.Element => {
                     <Typography variant="h6">Client Certificate</Typography>
                   </Grid>
                   <Grid item xs={8}>
-                    {connection?.clientCert?.info && (
-                      <>
-                        <CertDetails
-                          open={showDetail}
-                          onClose={() => setShowDetail(false)}
-                          certInfo={connection?.clientCert?.info}
-                        />
-                        <Chip
-                          label="Details"
-                          color="primary"
-                          onClick={() => setShowDetail(true)}
-                        />
-                      </>
-                    )}
+                    <Stack alignItems="flex-start" spacing={1}>
+                      {connection?.clientCertIssuerCn && (
+                        <Typography variant="subtitle2">
+                          Search system trust store by issuer &ldquo;
+                          {connection.clientCertIssuerCn}&rdquo;
+                        </Typography>
+                      )}
+                      {connection?.clientCert?.info && (
+                        <Stack
+                          direction="row"
+                          alignItems="baseline"
+                          spacing={1}
+                        >
+                          <CertDetails
+                            open={showDetail}
+                            onClose={() => setShowDetail(false)}
+                            certInfo={connection?.clientCert?.info}
+                          />
+                          <Typography variant="subtitle2">File:</Typography>
+                          <Chip
+                            label="Details"
+                            color="primary"
+                            onClick={() => setShowDetail(true)}
+                          />
+                        </Stack>
+                      )}
+                    </Stack>
                   </Grid>
                 </Grid>
               </Grid>

--- a/src/shared/pb/api.ts
+++ b/src/shared/pb/api.ts
@@ -320,6 +320,8 @@ export interface Connection {
   disableTlsVerification: boolean | undefined;
   caCert: Uint8Array | undefined;
   clientCert?: Certificate | undefined;
+  /** issuer Common Name to use when searching for a client certificate in the system trust store */
+  clientCertIssuerCn?: string | undefined;
 }
 
 function createBaseRecord(): Record {
@@ -2256,6 +2258,7 @@ function createBaseConnection(): Connection {
     disableTlsVerification: undefined,
     caCert: undefined,
     clientCert: undefined,
+    clientCertIssuerCn: undefined,
   };
 }
 
@@ -2284,6 +2287,9 @@ export const Connection = {
     }
     if (message.clientCert !== undefined) {
       Certificate.encode(message.clientCert, writer.uint32(58).fork()).ldelim();
+    }
+    if (message.clientCertIssuerCn !== undefined) {
+      writer.uint32(66).string(message.clientCertIssuerCn);
     }
     return writer;
   },
@@ -2316,6 +2322,9 @@ export const Connection = {
         case 7:
           message.clientCert = Certificate.decode(reader, reader.uint32());
           break;
+        case 8:
+          message.clientCertIssuerCn = reader.string();
+          break;
         default:
           reader.skipType(tag & 7);
           break;
@@ -2341,6 +2350,9 @@ export const Connection = {
       clientCert: isSet(object.clientCert)
         ? Certificate.fromJSON(object.clientCert)
         : undefined,
+      clientCertIssuerCn: isSet(object.clientCertIssuerCn)
+        ? String(object.clientCertIssuerCn)
+        : undefined,
     };
   },
 
@@ -2362,6 +2374,8 @@ export const Connection = {
       (obj.clientCert = message.clientCert
         ? Certificate.toJSON(message.clientCert)
         : undefined);
+    message.clientCertIssuerCn !== undefined &&
+      (obj.clientCertIssuerCn = message.clientCertIssuerCn);
     return obj;
   },
 
@@ -2379,6 +2393,7 @@ export const Connection = {
       object.clientCert !== undefined && object.clientCert !== null
         ? Certificate.fromPartial(object.clientCert)
         : undefined;
+    message.clientCertIssuerCn = object.clientCertIssuerCn ?? undefined;
     return message;
   },
 };


### PR DESCRIPTION
## Summary

Add a new option to the 'Add Connection' / 'Edit Connection' page to allow setting a certificate issuer Common Name, corresponding to the new `--client-cert-issuer-cn` option in pomerium-cli.

Update the connection view page to add a line to the 'Client Certificate' row when this option is set.

## Related issues

- #312 

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
