### PR TITLE
avoid existing eslint warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,10 +3,12 @@ module.exports = {
   rules: {
     // A temporary hack related to IDE not resolving correct package.json
     'import/no-extraneous-dependencies': 'off',
+    // console output is fine for a Node.js application
+    'no-console': 'off',
     // cause sometimes concat is more readable
     'prefer-template': 'off',
     'react-hooks/exhaustive-deps': 'off',
-    'typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-explicit-any': ['warn', { ignoreRestArgs: true }],
   },
   parserOptions: {
     ecmaVersion: 2020,


### PR DESCRIPTION
## Summary

Turn off the no-console rule and add the ignoreRestArgs option to the no-explicit-any rule. This should prevent the 3 existing lint warnings:

```
/home/runner/work/desktop-client/desktop-client/src/cli.ts
Warning:   32:39  warning  Unexpected console statement  no-console
Warning:   33:39  warning  Unexpected console statement  no-console

/home/runner/work/desktop-client/desktop-client/src/renderer/components/ExportDialog.tsx
Warning:   18:12  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

✖ 3 problems (0 errors, 3 warnings)
```
(from e.g. https://github.com/pomerium/desktop-client/actions/runs/6177042776/job/16767292926#step:5:88)

## Related issues

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
