### PR TITLE
desktop-client/ci: disable dependabot for npm

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,8 +5,3 @@ updates:
     schedule:
       interval: 'monthly'
     open-pull-requests-limit: 50
-  - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: 'monthly'
-    open-pull-requests-limit: 50


### PR DESCRIPTION
For https://github.com/pomerium/internal/issues/1594