### PR TITLE
update notarization parameters

### DIFF
--- a/.erb/scripts/Notarize.js
+++ b/.erb/scripts/Notarize.js
@@ -37,7 +37,8 @@ exports.default = async function notarizeMacos(context) {
     await notarize({
       appBundleId: build.appId,
       appPath: `${appOutDir}/${appName}.app`,
-      appleApiKey: process.env.APPLE_ID,
+      appleApiKey: process.env.APPLE_API_KEY_PATH,
+      appleApiKeyId: process.env.APPLE_ID,
       appleApiIssuer: process.env.APPLE_ID_KEY_ISSUER,
     });
   }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,9 @@ jobs:
       - name: Set up Apple ID Credentials
         run: |
           mkdir ~/private_keys
-          echo "${{ secrets.APPLE_ID_KEY }}" > ~/private_keys/AuthKey_${{ secrets.APPLE_ID }}.p8
+          key_path=~/private_keys/AuthKey_${{ secrets.APPLE_ID }}.p8
+          echo "${{ secrets.APPLE_ID_KEY }}" > "$key_path"
+          echo "APPLE_API_KEY_PATH=$key_path" >> "$GITHUB_ENV"
 
       - name: Release
         env:


### PR DESCRIPTION
## Summary

It looks like the new `notarytool` requires both `appleApiKey` and `appleApiKeyId` parameters. Update Notarize.js and the publish.yml workflow accordingly.

## Related issues

- https://github.com/pomerium/desktop-client/issues/317

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
