### PR TITLE
disable duplicate macOS notarization step

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
       "hardenedRuntime": true,
       "entitlements": "system_files/mac/common/entitlements.mac.plist",
       "entitlementsInherit": "system_files/mac/common/entitlements.mac.plist",
-      "gatekeeperAssess": false
+      "gatekeeperAssess": false,
+      "notarize": false
     },
     "dmg": {
       "sign": false,


### PR DESCRIPTION
## Summary

As of electron-builder v24, there is a built-in notarization step for macOS builds. This notarization step expects a slightly different set of environment variable values compared with what the existing Notarize.js script uses, which causes an error.

Disable the built-in notarization step in electron-builder, so we continue using the existing Notarize.js script for now.

## Related issues

- https://github.com/pomerium/desktop-client/issues/397


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
