### PR TITLE
add load connections form

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,8 +1,5 @@
 module.exports = {
-  extends: [
-      'erb',
-      'plugin:@typescript-eslint/recommended',
-  ],
+  extends: ['erb', 'plugin:@typescript-eslint/recommended'],
   rules: {
     // A temporary hack related to IDE not resolving correct package.json
     'import/no-extraneous-dependencies': 'off',
@@ -24,6 +21,8 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-this-alias': 'off',
     '@typescript-eslint/no-var-requires': 'off',
+    'no-await-in-loop': 'off',
+    'no-continue': 'off',
   },
   parserOptions: {
     ecmaVersion: 2020,

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -21,8 +21,12 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-this-alias': 'off',
     '@typescript-eslint/no-var-requires': 'off',
+    // because of how we do ipc we need to save routes one at a time, awaiting in a loop makes sense
     'no-await-in-loop': 'off',
+    // continue is fine
     'no-continue': 'off',
+    // eslint doesn't seem to understand for ... of
+    'no-restricted-syntax': 'off',
   },
   parserOptions: {
     ecmaVersion: 2020,

--- a/api.proto
+++ b/api.proto
@@ -19,6 +19,8 @@ service Config {
   rpc Export(ExportRequest) returns (ConfigData);
   // Import imports previously serialized records
   rpc Import(ImportRequest) returns (ImportResponse);
+  // FetchRoutes fetches all the routes from the routes portal.
+  rpc FetchRoutes(FetchRoutesRequest) returns (FetchRoutesResponse);
 }
 
 // Record represents a single tunnel record in the configuration
@@ -28,6 +30,7 @@ message Record {
   repeated string tags = 2;
   // connection data may be omitted if i.e. just manipulating the tags data
   optional Connection conn = 3;
+  optional string source = 4;
 }
 
 message Records { repeated Record records = 1; }
@@ -85,7 +88,8 @@ service Listener {
   // StatusUpdates opens a stream to listen to connection status updates
   // a client has to subscribe and continuously
   // listen to the broadcasted updates
-  rpc StatusUpdates(StatusUpdatesRequest) returns (stream ConnectionStatusUpdate);
+  rpc StatusUpdates(StatusUpdatesRequest)
+      returns (stream ConnectionStatusUpdate);
 }
 
 message ListenerUpdateRequest {
@@ -103,6 +107,28 @@ message ListenerStatus {
 message ListenerStatusResponse { map<string, ListenerStatus> listeners = 1; }
 
 message StatusUpdatesRequest { string connection_id = 1; }
+
+message FetchRoutesRequest {
+  string server_url = 1;
+  oneof tls_options {
+    bool disable_tls_verification = 2;
+    bytes ca_cert = 3;
+  }
+  optional Certificate client_cert = 4;
+  optional ClientCertFromStore client_cert_from_store = 5;
+}
+
+message FetchRoutesResponse { repeated PortalRoute routes = 1; }
+
+message PortalRoute {
+  string id = 1;
+  string name = 2;
+  string type = 3;
+  string from = 4;
+  string description = 5;
+  optional string connect_command = 6;
+  string logo_url = 7;
+}
 
 // ConnectionStatusUpdates represent connection state changes
 message ConnectionStatusUpdate {
@@ -211,10 +237,18 @@ message ClientCertFromStore {
   optional string subject_filter = 2;
 }
 
+enum Protocol {
+  UNKNOWN = 0;
+  TCP = 1;
+  UDP = 2;
+}
+
 // Connection
 message Connection {
   // name is a user friendly connection name that a user may define
   optional string name = 1;
+  // the protocol to use for the connection
+  optional Protocol protocol = 10;
   // remote_addr is a remote pomerium host:port
   string remote_addr = 2;
   // listen_address, if not provided, will assign a random port each time

--- a/package.json
+++ b/package.json
@@ -291,6 +291,7 @@
     "source-map-support": "^0.5.19",
     "ts-proto": "^1.166.2",
     "typescript-eslint": "^0.0.1-alpha.0",
+    "usehooks-ts": "^3.1.0",
     "validator": "^13.11.0"
   },
   "devEngines": {

--- a/package.json
+++ b/package.json
@@ -266,6 +266,7 @@
     "@emotion/styled": "^11.11.5",
     "@fontsource/dm-sans": "^5.0.20",
     "@grpc/grpc-js": "^1.9.15",
+    "@mui/icons-material": "^6.4.1",
     "@mui/lab": "^5.0.0-alpha.161",
     "@mui/material": "^5.15.5",
     "@mui/styles": "^5.15.5",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import SnackbarCloseButton from './renderer/components/SnackbarCloseButton';
 import ConnectForm from './renderer/pages/ConnectForm';
 import ConnectionView from './renderer/pages/ConnectionView';
 import Layout from './renderer/pages/Layout';
+import LoadForm from './renderer/pages/LoadForm';
 import ManageConnections from './renderer/pages/ManageConnections';
 import { THEMES } from './shared/constants';
 import createCustomTheme, { ThemeConfig } from './shared/theme';
@@ -74,6 +75,7 @@ const App: FC = () => {
                       element={<Navigate to="/manage" replace />}
                     />
                     <Route path="/manage" element={<ManageConnections />} />
+                    <Route path="/loadForm" element={<LoadForm />} />
                     <Route
                       path="/view_connection/:connectionID"
                       element={<ConnectionView />}

--- a/src/main.dev.ts
+++ b/src/main.dev.ts
@@ -48,7 +48,6 @@ import {
   LISTENER_LOG,
   GET_ALL_RECORDS,
   FETCH_ROUTES,
-  FetchRoutesResponseArgs,
   GetRecordsResponseArgs,
 } from './shared/constants';
 import {

--- a/src/main.dev.ts
+++ b/src/main.dev.ts
@@ -340,8 +340,7 @@ async function init(): Promise<void> {
     ipcMain.on(FETCH_ROUTES, (evt, args) => {
       const sendTo = evt?.sender ? evt.sender : mainWindow?.webContents;
       configClient.fetchRoutes(args as FetchRoutesRequest, (err, res) => {
-        const out: FetchRoutesResponseArgs = { err, res };
-        sendTo?.send(FETCH_ROUTES, args);
+        sendTo?.send(FETCH_ROUTES, { err, res });
       });
     });
     menu.app.on('web-contents-created', () => {

--- a/src/main.dev.ts
+++ b/src/main.dev.ts
@@ -47,6 +47,9 @@ import {
   ExportFile,
   LISTENER_LOG,
   GET_ALL_RECORDS,
+  FETCH_ROUTES,
+  FetchRoutesResponseArgs,
+  GetRecordsResponseArgs,
 } from './shared/constants';
 import {
   ConnectionStatusUpdate,
@@ -57,6 +60,7 @@ import {
   Record as ListenerRecord,
   Selector,
   StatusUpdatesRequest,
+  FetchRoutesRequest,
 } from './shared/pb/api';
 import Helper from './trayMenu/helper';
 
@@ -175,10 +179,8 @@ async function init(): Promise<void> {
     ipcMain.on(GET_RECORDS, (evt, selector: Selector) => {
       const sendTo = evt?.sender ? evt.sender : mainWindow?.webContents;
       configClient.list(selector, (err, res) => {
-        sendTo?.send(GET_RECORDS, {
-          err,
-          res,
-        });
+        const args: GetRecordsResponseArgs = { err, res };
+        sendTo?.send(GET_RECORDS, args);
         if (!err && res) {
           if (selector.all) {
             trayMenuHelper.setRecords(res.records);
@@ -200,10 +202,8 @@ async function init(): Promise<void> {
           tags: [],
         } as Selector,
         (err, res) => {
-          sendTo?.send(GET_ALL_RECORDS, {
-            err,
-            res,
-          });
+          const args: GetRecordsResponseArgs = { err, res };
+          sendTo?.send(GET_ALL_RECORDS, args);
           if (!err && res) {
             trayMenuHelper.setRecords(res.records);
             menu.tray.setContextMenu(trayMenuHelper.createContextMenu());
@@ -336,6 +336,13 @@ async function init(): Promise<void> {
       });
       // empty function otherwise causes fatal error on cancel !!!
       updateStream.on('error', () => {});
+    });
+    ipcMain.on(FETCH_ROUTES, (evt, args) => {
+      const sendTo = evt?.sender ? evt.sender : mainWindow?.webContents;
+      configClient.fetchRoutes(args as FetchRoutesRequest, (err, res) => {
+        const args: FetchRoutesResponseArgs = { err, res };
+        sendTo?.send(FETCH_ROUTES, args);
+      });
     });
     menu.app.on('web-contents-created', () => {
       contextMenu();

--- a/src/main.dev.ts
+++ b/src/main.dev.ts
@@ -340,7 +340,7 @@ async function init(): Promise<void> {
     ipcMain.on(FETCH_ROUTES, (evt, args) => {
       const sendTo = evt?.sender ? evt.sender : mainWindow?.webContents;
       configClient.fetchRoutes(args as FetchRoutesRequest, (err, res) => {
-        const args: FetchRoutesResponseArgs = { err, res };
+        const out: FetchRoutesResponseArgs = { err, res };
         sendTo?.send(FETCH_ROUTES, args);
       });
     });

--- a/src/renderer/components/AdvancedSettingsAccordion.tsx
+++ b/src/renderer/components/AdvancedSettingsAccordion.tsx
@@ -1,0 +1,39 @@
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Typography,
+} from '@mui/material';
+import React, { FC } from 'react';
+import { ChevronDown } from 'react-feather';
+
+export type AdvancedSettingsAccordionProps = React.PropsWithChildren<{}>;
+const AdvancedSettingsAccordion: FC<AdvancedSettingsAccordionProps> = ({
+  children,
+}) => {
+  return (
+    <Accordion
+      sx={{
+        backgroundColor: 'background.paper',
+        marginTop: 2,
+        paddingLeft: 2,
+        paddingRight: 2,
+        borderRadius: 4,
+        '&:before': {
+          display: 'none',
+        },
+      }}
+      square={false}
+    >
+      <AccordionSummary
+        expandIcon={<ChevronDown />}
+        aria-controls="advanced-settings-content"
+        id="advanced-settings-header"
+      >
+        <Typography variant="h5">Advanced Settings</Typography>
+      </AccordionSummary>
+      <AccordionDetails>{children}</AccordionDetails>
+    </Accordion>
+  );
+};
+export default AdvancedSettingsAccordion;

--- a/src/renderer/components/AdvancedSettingsAccordion.tsx
+++ b/src/renderer/components/AdvancedSettingsAccordion.tsx
@@ -7,7 +7,7 @@ import {
 import React, { FC } from 'react';
 import { ChevronDown } from 'react-feather';
 
-export type AdvancedSettingsAccordionProps = React.PropsWithChildren<{}>;
+export type AdvancedSettingsAccordionProps = React.PropsWithChildren;
 const AdvancedSettingsAccordion: FC<AdvancedSettingsAccordionProps> = ({
   children,
 }) => {

--- a/src/renderer/components/NewConnectionButton.tsx
+++ b/src/renderer/components/NewConnectionButton.tsx
@@ -14,7 +14,7 @@ import {
 import React, { FC, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { usePopover } from '../hooks/use-popover';
+import usePopover from '../hooks/use-popover';
 
 const NewConnectionButton: FC = () => {
   const popover = usePopover<HTMLButtonElement>();
@@ -94,9 +94,9 @@ const NewConnectionButton: FC = () => {
                   {options.map((option) => (
                     <MenuItem
                       key={option.key}
-                      onClick={(_event) => handleMenuItemClick(option.key)}
+                      onClick={() => handleMenuItemClick(option.key)}
                       sx={{ borderRadius: 1 }}
-                      divider={true}
+                      divider
                     >
                       <Stack
                         direction="row"

--- a/src/renderer/components/NewConnectionButton.tsx
+++ b/src/renderer/components/NewConnectionButton.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-props-no-spreading */
 import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
 import {
   Button,
@@ -42,6 +43,8 @@ const NewConnectionButton: FC = () => {
         navigate(`/connectForm`, {
           replace: true,
         });
+        break;
+      default:
         break;
     }
   };

--- a/src/renderer/components/NewConnectionButton.tsx
+++ b/src/renderer/components/NewConnectionButton.tsx
@@ -1,0 +1,117 @@
+import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline';
+import {
+  Button,
+  ClickAwayListener,
+  Grow,
+  MenuItem,
+  MenuList,
+  Paper,
+  Popper,
+  Stack,
+  Typography,
+} from '@mui/material';
+import React, { FC, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { usePopover } from '../hooks/use-popover';
+
+const NewConnectionButton: FC = () => {
+  const popover = usePopover<HTMLButtonElement>();
+  const navigate = useNavigate();
+  const anchorRef = useRef<HTMLDivElement>(null);
+
+  const handleClose = (event: Event) => {
+    if (
+      anchorRef.current &&
+      anchorRef.current.contains(event.target as HTMLElement)
+    ) {
+      return;
+    }
+    popover.handleClose();
+  };
+
+  const handleMenuItemClick = (key: string) => {
+    popover.handleClose();
+    switch (key) {
+      case 'load':
+        navigate(`/loadForm`, {
+          replace: true,
+        });
+        break;
+      case 'add':
+        navigate(`/connectForm`, {
+          replace: true,
+        });
+        break;
+    }
+  };
+
+  const options = [
+    {
+      key: 'load',
+      title: 'Load Connections',
+    },
+    {
+      key: 'add',
+      title: 'Add Connecton',
+    },
+  ];
+
+  return (
+    <>
+      <Button
+        variant="contained"
+        color="primary"
+        ref={popover.anchorRef}
+        onClick={popover.handleOpen}
+        startIcon={<AddCircleOutlineIcon />}
+      >
+        <Typography variant="button">New Connection</Typography>
+      </Button>
+      <Popper
+        sx={{ zIndex: 1 }}
+        open={popover.open}
+        anchorEl={popover.anchorRef.current}
+        role={undefined}
+        transition
+        disablePortal
+        placement="bottom-end"
+      >
+        {({ TransitionProps, placement }) => (
+          <Grow
+            {...TransitionProps}
+            style={{
+              transformOrigin:
+                placement === 'bottom' ? 'center top' : 'center bottom',
+            }}
+          >
+            <Paper>
+              <ClickAwayListener onClickAway={handleClose}>
+                <MenuList id="split-button-menu" autoFocusItem disablePadding>
+                  {options.map((option) => (
+                    <MenuItem
+                      key={option.key}
+                      onClick={(_event) => handleMenuItemClick(option.key)}
+                      sx={{ borderRadius: 1 }}
+                      divider={true}
+                    >
+                      <Stack
+                        direction="row"
+                        spacing={1}
+                        justifyContent="center"
+                      >
+                        <Typography variant="button">{option.title}</Typography>
+                      </Stack>
+                    </MenuItem>
+                  ))}
+                </MenuList>
+              </ClickAwayListener>
+            </Paper>
+          </Grow>
+        )}
+      </Popper>
+    </>
+  );
+};
+
+export default NewConnectionButton;

--- a/src/renderer/components/TagSelector.tsx
+++ b/src/renderer/components/TagSelector.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/jsx-props-no-spreading */
 import { Autocomplete } from '@mui/material';
 import { ipcRenderer } from 'electron';
 import React, { FC, useEffect, useState } from 'react';

--- a/src/renderer/components/TagSelector.tsx
+++ b/src/renderer/components/TagSelector.tsx
@@ -32,7 +32,6 @@ const TagSelector: FC<TagSelectorProps> = ({ tags, onChangeTags }) => {
         options={tagOptions}
         value={tags || []}
         onChange={(_, arr) => {
-          console.log('CHANGE TAGS');
           saveTags(arr);
         }}
         renderInput={(params) => (

--- a/src/renderer/components/TagSelector.tsx
+++ b/src/renderer/components/TagSelector.tsx
@@ -1,0 +1,57 @@
+import { Autocomplete } from '@mui/material';
+import { ipcRenderer } from 'electron';
+import React, { FC, useEffect, useState } from 'react';
+
+import { GET_UNIQUE_TAGS } from '../../shared/constants';
+import { formatTag } from '../../shared/validators';
+import TextField from './TextField';
+
+export type TagSelectorProps = {
+  tags: string[];
+  onChangeTags: (tags: string[]) => void;
+};
+const TagSelector: FC<TagSelectorProps> = ({ tags, onChangeTags }) => {
+  const [tagOptions, setTagOptions] = useState([] as string[]);
+
+  useEffect(() => {
+    ipcRenderer.once(GET_UNIQUE_TAGS, (_, args) => {
+      if (args.tags && !args.err) {
+        setTagOptions(args.tags);
+      }
+    });
+    ipcRenderer.send(GET_UNIQUE_TAGS);
+  }, []);
+
+  const saveTags = (arr: string[]): void => onChangeTags(arr.map(formatTag));
+
+  return (
+    <>
+      <Autocomplete
+        multiple
+        id="tags-outlined"
+        options={tagOptions}
+        value={tags || []}
+        onChange={(_, arr) => {
+          console.log('CHANGE TAGS');
+          saveTags(arr);
+        }}
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            variant="outlined"
+            label="Tags..."
+            placeholder="Tags"
+            onKeyDown={(e) => {
+              const element = e.target as HTMLInputElement;
+              const { value } = element;
+              if (e.key === 'Enter' && value.trim()) {
+                saveTags(tags.concat(value));
+              }
+            }}
+          />
+        )}
+      />
+    </>
+  );
+};
+export default TagSelector;

--- a/src/renderer/hooks/use-popover.ts
+++ b/src/renderer/hooks/use-popover.ts
@@ -9,7 +9,7 @@ interface PopoverController<T> {
   open: boolean;
 }
 
-export function usePopover<T = HTMLElement>(): PopoverController<T> {
+function usePopover<T = HTMLElement>(): PopoverController<T> {
   const anchorRef = useRef<T | null>(null);
   const [open, setOpen] = useState<boolean>(false);
 
@@ -33,3 +33,4 @@ export function usePopover<T = HTMLElement>(): PopoverController<T> {
     open,
   };
 }
+export default usePopover;

--- a/src/renderer/hooks/use-popover.ts
+++ b/src/renderer/hooks/use-popover.ts
@@ -1,0 +1,35 @@
+import type { MutableRefObject } from 'react';
+import { useCallback, useRef, useState } from 'react';
+
+interface PopoverController<T> {
+  anchorRef: MutableRefObject<T | null>;
+  handleOpen: () => void;
+  handleClose: () => void;
+  handleToggle: () => void;
+  open: boolean;
+}
+
+export function usePopover<T = HTMLElement>(): PopoverController<T> {
+  const anchorRef = useRef<T | null>(null);
+  const [open, setOpen] = useState<boolean>(false);
+
+  const handleOpen = useCallback((): void => {
+    setOpen(true);
+  }, []);
+
+  const handleClose = useCallback((): void => {
+    setOpen(false);
+  }, []);
+
+  const handleToggle = useCallback((): void => {
+    setOpen((prevState) => !prevState);
+  }, []);
+
+  return {
+    anchorRef,
+    handleClose,
+    handleOpen,
+    handleToggle,
+    open,
+  };
+}

--- a/src/renderer/pages/ConnectForm.tsx
+++ b/src/renderer/pages/ConnectForm.tsx
@@ -1,9 +1,5 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Autocomplete,
   Button,
   CardContent,
   Container,
@@ -13,7 +9,7 @@ import {
 import { ipcRenderer } from 'electron';
 import { useSnackbar } from 'notistack';
 import React, { FC, useEffect, useState } from 'react';
-import { CheckCircle, ChevronDown } from 'react-feather';
+import { CheckCircle } from 'react-feather';
 import { useParams } from 'react-router-dom';
 
 import {
@@ -25,10 +21,11 @@ import {
   VIEW_CONNECTION_LIST,
 } from '../../shared/constants';
 import { Connection, Record, Selector } from '../../shared/pb/api';
-import { formatTag } from '../../shared/validators';
 import AdvancedConnectionSettings from '../components/AdvancedConnectionSettings';
+import AdvancedSettingsAccordion from '../components/AdvancedSettingsAccordion';
 import BeforeBackActionDialog from '../components/BeforeBackActionDialog';
 import StyledCard from '../components/StyledCard';
+import TagSelector from '../components/TagSelector';
 import TextField from '../components/TextField';
 
 interface Props {
@@ -51,7 +48,6 @@ const ConnectForm: FC<Props> = () => {
   const [tags, setTags] = useState<string[]>([]);
   const [connection, setConnection] = useState(initialConnData);
   const [originalConnection, setOriginalConnection] = useState(initialConnData);
-  const [tagOptions, setTagOptions] = useState([] as string[]);
   const handleSubmit = (evt: React.FormEvent): void => {
     evt.preventDefault();
   };
@@ -72,12 +68,6 @@ const ConnectForm: FC<Props> = () => {
         setOriginalConnection(conn || initialConnData);
       }
     });
-    ipcRenderer.once(GET_UNIQUE_TAGS, (_, args) => {
-      if (args.tags && !args.err) {
-        setTagOptions(args.tags);
-      }
-    });
-    ipcRenderer.send(GET_UNIQUE_TAGS);
 
     if (connectionID) {
       ipcRenderer.send(GET_RECORDS, {
@@ -98,8 +88,6 @@ const ConnectForm: FC<Props> = () => {
       ...{ name: value || undefined },
     });
   };
-
-  const saveTags = (arr: string[]): void => setTags(arr.map(formatTag));
 
   const saveDestination = (value: string): void => {
     setConnection({
@@ -209,62 +197,18 @@ const ConnectForm: FC<Props> = () => {
                 />
               </Grid>
               <Grid item xs={12}>
-                <Autocomplete
-                  multiple
-                  id="tags-outlined"
-                  options={tagOptions}
-                  value={tags || []}
-                  onChange={(_, arr) => {
-                    saveTags(arr);
-                  }}
-                  renderInput={(params) => (
-                    <TextField
-                      {...params}
-                      variant="outlined"
-                      label="Tags..."
-                      placeholder="Tags"
-                      onKeyDown={(e) => {
-                        const element = e.target as HTMLInputElement;
-                        const { value } = element;
-                        if (e.key === 'Enter' && value.trim()) {
-                          saveTags(tags.concat(value));
-                        }
-                      }}
-                    />
-                  )}
-                />
+                <TagSelector tags={tags} onChangeTags={setTags} />
               </Grid>
             </Grid>
           </CardContent>
         </StyledCard>
 
-        <Accordion
-          sx={{
-            backgroundColor: 'background.paper',
-            marginTop: 2,
-            paddingLeft: 2,
-            paddingRight: 2,
-            borderRadius: 4,
-            '&:before': {
-              display: 'none',
-            },
-          }}
-          square={false}
-        >
-          <AccordionSummary
-            expandIcon={<ChevronDown />}
-            aria-controls="advanced-settings-content"
-            id="advanced-settings-header"
-          >
-            <Typography variant="h5">Advanced Settings</Typography>
-          </AccordionSummary>
-          <AccordionDetails>
-            <AdvancedConnectionSettings
-              connection={connection}
-              onChangeConnection={setConnection}
-            />
-          </AccordionDetails>
-        </Accordion>
+        <AdvancedSettingsAccordion>
+          <AdvancedConnectionSettings
+            connection={connection}
+            onChangeConnection={setConnection}
+          />
+        </AdvancedSettingsAccordion>
 
         <Grid
           container

--- a/src/renderer/pages/ConnectForm.tsx
+++ b/src/renderer/pages/ConnectForm.tsx
@@ -4,6 +4,7 @@ import {
   CardContent,
   Container,
   Grid,
+  Stack,
   Typography,
 } from '@mui/material';
 import { ipcRenderer } from 'electron';
@@ -46,6 +47,7 @@ const initialConnData: Connection = {
 const ConnectForm: FC<Props> = () => {
   const [showBackWarning, setShowBackWarning] = useState(false);
   const [tags, setTags] = useState<string[]>([]);
+  const [source, setSource] = useState<string>('');
   const [connection, setConnection] = useState(initialConnData);
   const [originalConnection, setOriginalConnection] = useState(initialConnData);
   const handleSubmit = (evt: React.FormEvent): void => {
@@ -66,6 +68,7 @@ const ConnectForm: FC<Props> = () => {
         const { conn } = args.res.records[0];
         setConnection(conn || initialConnData);
         setOriginalConnection(conn || initialConnData);
+        setSource(args.res.records[0].source);
       }
     });
 
@@ -115,6 +118,7 @@ const ConnectForm: FC<Props> = () => {
     const record = {
       tags,
       conn: connection,
+      source,
     } as Record;
 
     if (connectionID) {
@@ -144,80 +148,73 @@ const ConnectForm: FC<Props> = () => {
   };
 
   return (
-    <Container maxWidth={false}>
+    <Container maxWidth={false} sx={{ pt: 4 }}>
       <BeforeBackActionDialog
         open={showBackWarning}
         onClose={() => setShowBackWarning(false)}
       />
       <form onSubmit={handleSubmit}>
-        <Grid sx={{ pt: 4 }}>
-          <Grid container alignItems="flex-start">
-            <Grid item xs={12}>
-              <Typography variant="h3" color="textPrimary">
-                {connectionID ? 'Edit' : 'Add'} Connection
-              </Typography>
+        <Stack spacing={2}>
+          <Grid>
+            <Grid container alignItems="flex-start">
+              <Grid item xs={12}>
+                <Typography variant="h3" color="textPrimary">
+                  {connectionID ? 'Edit' : 'Add'} Connection
+                </Typography>
+              </Grid>
             </Grid>
           </Grid>
-        </Grid>
+          <StyledCard>
+            <CardContent>
+              <Grid container spacing={2}>
+                <Grid item xs={12}>
+                  <TextField
+                    fullWidth
+                    required
+                    label="Name"
+                    value={connection?.name || ''}
+                    onChange={(evt): void => saveName(evt.target.value)}
+                    variant="outlined"
+                    autoFocus
+                    helperText="Name of the route."
+                  />
+                </Grid>
+                <Grid item xs={12}>
+                  <TextField
+                    fullWidth
+                    required
+                    label="Destination"
+                    value={connection?.remoteAddr}
+                    onChange={(evt): void => saveDestination(evt.target.value)}
+                    variant="outlined"
+                    helperText="The remote address to connect to. Example: mysql.example.com:3306 or tcp+https://proxy.example.com/mysql.example.com:3306"
+                  />
+                </Grid>
+                <Grid item xs={12}>
+                  <TextField
+                    fullWidth
+                    label="Local Address"
+                    value={connection?.listenAddr || ''}
+                    onChange={(evt): void => saveLocal(evt.target.value)}
+                    variant="outlined"
+                    helperText="The port or local address you want to connect to. Ex. :8888 or 127.0.0.1:8888"
+                  />
+                </Grid>
+                <Grid item xs={12}>
+                  <TagSelector tags={tags} onChangeTags={setTags} />
+                </Grid>
+              </Grid>
+            </CardContent>
+          </StyledCard>
 
-        <StyledCard>
-          <CardContent>
-            <Grid container spacing={2}>
-              <Grid item xs={12}>
-                <TextField
-                  fullWidth
-                  required
-                  label="Name"
-                  value={connection?.name || ''}
-                  onChange={(evt): void => saveName(evt.target.value)}
-                  variant="outlined"
-                  autoFocus
-                  helperText="Name of the route."
-                />
-              </Grid>
-              <Grid item xs={12}>
-                <TextField
-                  fullWidth
-                  required
-                  label="Destination"
-                  value={connection?.remoteAddr}
-                  onChange={(evt): void => saveDestination(evt.target.value)}
-                  variant="outlined"
-                  helperText="The remote address to connect to. Example: mysql.example.com:3306 or tcp+https://proxy.example.com/mysql.example.com:3306"
-                />
-              </Grid>
-              <Grid item xs={12}>
-                <TextField
-                  fullWidth
-                  label="Local Address"
-                  value={connection?.listenAddr || ''}
-                  onChange={(evt): void => saveLocal(evt.target.value)}
-                  variant="outlined"
-                  helperText="The port or local address you want to connect to. Ex. :8888 or 127.0.0.1:8888"
-                />
-              </Grid>
-              <Grid item xs={12}>
-                <TagSelector tags={tags} onChangeTags={setTags} />
-              </Grid>
-            </Grid>
-          </CardContent>
-        </StyledCard>
+          <AdvancedSettingsAccordion>
+            <AdvancedConnectionSettings
+              connection={connection}
+              onChangeConnection={setConnection}
+            />
+          </AdvancedSettingsAccordion>
 
-        <AdvancedSettingsAccordion>
-          <AdvancedConnectionSettings
-            connection={connection}
-            onChangeConnection={setConnection}
-          />
-        </AdvancedSettingsAccordion>
-
-        <Grid
-          container
-          spacing={2}
-          alignItems="flex-end"
-          justifyContent="flex-end"
-          sx={{ mt: 3 }}
-        >
-          <Grid item>
+          <Stack direction="row" spacing={2} justifyContent="flex-end">
             <Button
               type="button"
               variant="contained"
@@ -226,8 +223,6 @@ const ConnectForm: FC<Props> = () => {
             >
               Back
             </Button>
-          </Grid>
-          <Grid item>
             <Button
               type="button"
               variant="contained"
@@ -238,8 +233,8 @@ const ConnectForm: FC<Props> = () => {
             >
               Save
             </Button>
-          </Grid>
-        </Grid>
+          </Stack>
+        </Stack>
       </form>
     </Container>
   );

--- a/src/renderer/pages/ConnectionView.tsx
+++ b/src/renderer/pages/ConnectionView.tsx
@@ -236,364 +236,366 @@ function ConnectionView(): ReactElement {
           exportFile={exportFile}
           onClose={() => setExportFile(null)}
         />
-        <Container maxWidth={false}>
-          <Grid sx={{ pt: 4 }}>
-            <Grid container alignItems="flex-start">
-              <Grid item xs={5}>
-                <Typography variant="h3" color="textPrimary">
-                  {connection.name}
-                </Typography>
-              </Grid>
-              <Grid item xs={7} container justifyContent="flex-end">
-                <Grid item>
-                  <Button
-                    size="small"
-                    type="button"
-                    color="primary"
-                    onClick={() => ipcRenderer.send(EDIT, connectionID)}
-                    endIcon={<Edit />}
-                  >
-                    Edit
-                  </Button>
+        <Container maxWidth={false} sx={{ pt: 4 }}>
+          <Stack spacing={2}>
+            <Grid>
+              <Grid container alignItems="flex-start">
+                <Grid item xs={5}>
+                  <Typography variant="h3" color="textPrimary">
+                    {connection.name}
+                  </Typography>
                 </Grid>
-                <Grid item>
-                  <Button
-                    size="small"
-                    type="button"
-                    color="primary"
-                    onClick={() =>
-                      setExportFile({
-                        filename: connection?.name || 'download',
-                        selector: {
-                          all: false,
-                          ids: [connectionID as string],
-                          tags: [],
-                        },
-                      })
-                    }
-                    endIcon={<Export />}
-                  >
-                    Export
-                  </Button>
-                </Grid>
-                <Grid item>
-                  <Button
-                    size="small"
-                    type="button"
-                    color="primary"
-                    onClick={deleteAndRedirect}
-                    endIcon={<Delete />}
-                  >
-                    Delete
-                  </Button>
-                </Grid>
-                <Grid item>
-                  {connected && (
+                <Grid item xs={7} container justifyContent="flex-end">
+                  <Grid item>
                     <Button
                       size="small"
                       type="button"
                       color="primary"
-                      onClick={() => toggleConnected()}
-                      endIcon={<Disconnected />}
+                      onClick={() => ipcRenderer.send(EDIT, connectionID)}
+                      endIcon={<Edit />}
                     >
-                      Disconnect
+                      Edit
                     </Button>
-                  )}
-                  {!connected && (
+                  </Grid>
+                  <Grid item>
                     <Button
                       size="small"
                       type="button"
                       color="primary"
-                      onClick={() => toggleConnected()}
-                      endIcon={<Connected />}
+                      onClick={() =>
+                        setExportFile({
+                          filename: connection?.name || 'download',
+                          selector: {
+                            all: false,
+                            ids: [connectionID as string],
+                            tags: [],
+                          },
+                        })
+                      }
+                      endIcon={<Export />}
                     >
-                      Connect
+                      Export
                     </Button>
-                  )}
+                  </Grid>
+                  <Grid item>
+                    <Button
+                      size="small"
+                      type="button"
+                      color="primary"
+                      onClick={deleteAndRedirect}
+                      endIcon={<Delete />}
+                    >
+                      Delete
+                    </Button>
+                  </Grid>
+                  <Grid item>
+                    {connected && (
+                      <Button
+                        size="small"
+                        type="button"
+                        color="primary"
+                        onClick={() => toggleConnected()}
+                        endIcon={<Disconnected />}
+                      >
+                        Disconnect
+                      </Button>
+                    )}
+                    {!connected && (
+                      <Button
+                        size="small"
+                        type="button"
+                        color="primary"
+                        onClick={() => toggleConnected()}
+                        endIcon={<Connected />}
+                      >
+                        Connect
+                      </Button>
+                    )}
+                  </Grid>
                 </Grid>
               </Grid>
             </Grid>
-          </Grid>
 
-          <StyledCard>
-            <CardContent>
-              <Grid container spacing={2}>
-                <Grid container item xs={12} alignItems="center">
-                  <Grid item xs={4}>
-                    <Typography variant="h6">Destination URL</Typography>
-                  </Grid>
-                  <Grid item xs={8}>
-                    <Typography variant="subtitle2">
-                      {connection.remoteAddr}
-                    </Typography>
-                  </Grid>
-                </Grid>
-                <Grid item xs={12}>
-                  <Divider />
-                </Grid>
-                <Grid container item xs={12} alignItems="center">
-                  <Grid item xs={4}>
-                    <Typography variant="h6">Listener Address</Typography>
-                  </Grid>
-                  <Grid item xs={8}>
-                    <Typography variant="subtitle2">
-                      {connectionPort || connection.listenAddr}
-                    </Typography>
-                  </Grid>
-                </Grid>
-                <Grid item xs={12}>
-                  <Divider />
-                </Grid>
-                <Grid container item xs={12} alignItems="center">
-                  <Grid item xs={4}>
-                    <Typography variant="h6">Tags</Typography>
-                  </Grid>
-                  <Grid item xs={8}>
-                    <Typography variant="subtitle2">
-                      {tags?.join(', ')}
-                    </Typography>
-                  </Grid>
-                </Grid>
-              </Grid>
-            </CardContent>
-          </StyledCard>
-
-          <Accordion
-            sx={{
-              backgroundColor: 'background.paper',
-              marginTop: 2,
-              paddingLeft: 2,
-              paddingRight: 2,
-              borderRadius: 4,
-              '&:before': {
-                display: 'none',
-              },
-            }}
-            square={false}
-          >
-            <AccordionSummary
-              expandIcon={<ChevronDown />}
-              aria-controls="advanced-settings-content"
-              id="advanced-settings-header"
-            >
-              <Typography variant="h5">Advanced Settings</Typography>
-            </AccordionSummary>
-            <AccordionDetails>
-              <Grid container spacing={2}>
-                <Grid container item xs={12} alignItems="center">
-                  <Grid item xs={4}>
-                    <Typography variant="h6">
-                      Disable TLS Verification
-                    </Typography>
-                  </Grid>
-                  <Grid item xs={8}>
-                    <Typography variant="subtitle2">
-                      {connection.disableTlsVerification ? 'Yes' : 'No'}
-                    </Typography>
-                  </Grid>
-                </Grid>
-                <Grid item xs={12}>
-                  <Divider />
-                </Grid>
-                <Grid container item xs={12} alignItems="center">
-                  <Grid item xs={4}>
-                    <Typography variant="h6">Pomerium URL</Typography>
-                  </Grid>
-                  <Grid item xs={8}>
-                    <Typography variant="subtitle2">
-                      {connection.pomeriumUrl}
-                    </Typography>
-                  </Grid>
-                </Grid>
-                <Grid item xs={12}>
-                  <Divider />
-                </Grid>
-                <Grid container item xs={12} alignItems="center">
-                  <Grid item xs={4}>
-                    <Typography variant="h6">Client Certificate</Typography>
-                  </Grid>
-                  <Grid item xs={8}>
-                    <Stack alignItems="flex-start" spacing={1}>
-                      {connection?.clientCertFromStore !== undefined && (
-                        <Typography variant="subtitle2">
-                          Search OS certificate store
-                          {clientCertFiltersSummary && (
-                            <>
-                              <br />({clientCertFiltersSummary})
-                            </>
-                          )}
-                        </Typography>
-                      )}
-                      {connection?.clientCert?.info && (
-                        <Stack
-                          direction="row"
-                          alignItems="baseline"
-                          spacing={1}
-                        >
-                          <CertDetails
-                            open={showDetail}
-                            onClose={() => setShowDetail(false)}
-                            certInfo={connection?.clientCert?.info}
-                          />
-                          <Typography variant="subtitle2">File:</Typography>
-                          <Chip
-                            label="Details"
-                            color="primary"
-                            onClick={() => setShowDetail(true)}
-                          />
-                        </Stack>
-                      )}
-                    </Stack>
-                  </Grid>
-                </Grid>
-              </Grid>
-            </AccordionDetails>
-          </Accordion>
-          <Accordion
-            sx={{
-              backgroundColor: 'background.paper',
-              marginTop: 2,
-              paddingLeft: 2,
-              paddingRight: 2,
-              borderRadius: 4,
-              '&:before': {
-                display: 'none',
-              },
-            }}
-            square={false}
-          >
-            <AccordionSummary
-              expandIcon={<ChevronDown />}
-              aria-controls="log-content"
-              id="log-header"
-            >
-              <Grid container item alignItems="center">
-                <Grid item xs={9}>
-                  <Typography variant="h5">Logs</Typography>
-                </Grid>
-                {!!logs?.length && (
-                  <Grid item xs={3}>
-                    <Button
-                      size="small"
-                      type="button"
-                      color="primary"
-                      disabled={!filteredLogs?.length}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        exportLogs();
-                      }}
-                    >
-                      Export Logs
-                    </Button>
-                    <IconButton
-                      aria-controls="filter-menu"
-                      aria-haspopup="true"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        toggleMenu(e);
-                      }}
-                      aria-label="Menu for filters/export"
-                      size="large"
-                    >
-                      <ExportJSON />
-                    </IconButton>
-                    <Menu
-                      id="filter-menu"
-                      anchorEl={menuAnchor}
-                      keepMounted
-                      open={Boolean(menuAnchor)}
-                      onClose={handleMenuClose}
-                    >
-                      <MenuItem
-                        key="errorFilter"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setErrorFilter(!errorFilter);
-                        }}
-                      >
-                        <Checkbox
-                          color="primary"
-                          checked={errorFilter}
-                          onChange={(e) => {
-                            e.stopPropagation();
-                            setErrorFilter(!errorFilter);
-                          }}
-                          value={errorFilter}
-                        />
-                        Error
-                      </MenuItem>
-                      <MenuItem
-                        key="infoFilter"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setInfoFilter(!infoFilter);
-                        }}
-                      >
-                        <Checkbox
-                          color="primary"
-                          checked={infoFilter}
-                          onChange={(e) => {
-                            e.stopPropagation();
-                            setInfoFilter(!infoFilter);
-                          }}
-                          value={infoFilter}
-                        />
-                        Info
-                      </MenuItem>
-                      <MenuItem key="exportToJSON">
-                        <Button
-                          size="small"
-                          type="button"
-                          color="primary"
-                          variant="contained"
-                          disabled={!filteredLogs?.length}
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            exportLogs();
-                          }}
-                        >
-                          Export Logs
-                        </Button>
-                      </MenuItem>
-                    </Menu>
-                  </Grid>
-                )}
-              </Grid>
-            </AccordionSummary>
-            <AccordionDetails>
-              <Grid container spacing={2}>
-                {filteredLogs.map((log) => (
-                  <Grid
-                    item
-                    container
-                    alignItems="center"
-                    key={Math.random()}
-                    sx={{
-                      borderTop: '1px solid #E3E3E3',
-                    }}
-                  >
-                    <Grid item xs={2}>
-                      {log.status === 'info' && (
-                        <Info style={{ color: 'blue' }} />
-                      )}
-                      {log.status === 'error' && (
-                        <AlertTriangle style={{ color: 'orange' }} />
-                      )}
-                    </Grid>
+            <StyledCard>
+              <CardContent>
+                <Grid container spacing={2}>
+                  <Grid container item xs={12} alignItems="center">
                     <Grid item xs={4}>
-                      <Typography>{log.date}</Typography>
+                      <Typography variant="h6">Destination URL</Typography>
                     </Grid>
-                    <Grid item xs={6}>
-                      <Typography style={{ wordWrap: 'break-word' }}>
-                        {log.message}
+                    <Grid item xs={8}>
+                      <Typography variant="subtitle2">
+                        {connection.remoteAddr}
                       </Typography>
                     </Grid>
                   </Grid>
-                ))}
-              </Grid>
-            </AccordionDetails>
-          </Accordion>
-          <Box minHeight="20px" />
+                  <Grid item xs={12}>
+                    <Divider />
+                  </Grid>
+                  <Grid container item xs={12} alignItems="center">
+                    <Grid item xs={4}>
+                      <Typography variant="h6">Listener Address</Typography>
+                    </Grid>
+                    <Grid item xs={8}>
+                      <Typography variant="subtitle2">
+                        {connectionPort || connection.listenAddr}
+                      </Typography>
+                    </Grid>
+                  </Grid>
+                  <Grid item xs={12}>
+                    <Divider />
+                  </Grid>
+                  <Grid container item xs={12} alignItems="center">
+                    <Grid item xs={4}>
+                      <Typography variant="h6">Tags</Typography>
+                    </Grid>
+                    <Grid item xs={8}>
+                      <Typography variant="subtitle2">
+                        {tags?.join(', ')}
+                      </Typography>
+                    </Grid>
+                  </Grid>
+                </Grid>
+              </CardContent>
+            </StyledCard>
+
+            <Accordion
+              sx={{
+                backgroundColor: 'background.paper',
+                marginTop: 2,
+                paddingLeft: 2,
+                paddingRight: 2,
+                borderRadius: 4,
+                '&:before': {
+                  display: 'none',
+                },
+              }}
+              square={false}
+            >
+              <AccordionSummary
+                expandIcon={<ChevronDown />}
+                aria-controls="advanced-settings-content"
+                id="advanced-settings-header"
+              >
+                <Typography variant="h5">Advanced Settings</Typography>
+              </AccordionSummary>
+              <AccordionDetails>
+                <Grid container spacing={2}>
+                  <Grid container item xs={12} alignItems="center">
+                    <Grid item xs={4}>
+                      <Typography variant="h6">
+                        Disable TLS Verification
+                      </Typography>
+                    </Grid>
+                    <Grid item xs={8}>
+                      <Typography variant="subtitle2">
+                        {connection.disableTlsVerification ? 'Yes' : 'No'}
+                      </Typography>
+                    </Grid>
+                  </Grid>
+                  <Grid item xs={12}>
+                    <Divider />
+                  </Grid>
+                  <Grid container item xs={12} alignItems="center">
+                    <Grid item xs={4}>
+                      <Typography variant="h6">Pomerium URL</Typography>
+                    </Grid>
+                    <Grid item xs={8}>
+                      <Typography variant="subtitle2">
+                        {connection.pomeriumUrl}
+                      </Typography>
+                    </Grid>
+                  </Grid>
+                  <Grid item xs={12}>
+                    <Divider />
+                  </Grid>
+                  <Grid container item xs={12} alignItems="center">
+                    <Grid item xs={4}>
+                      <Typography variant="h6">Client Certificate</Typography>
+                    </Grid>
+                    <Grid item xs={8}>
+                      <Stack alignItems="flex-start" spacing={1}>
+                        {connection?.clientCertFromStore !== undefined && (
+                          <Typography variant="subtitle2">
+                            Search OS certificate store
+                            {clientCertFiltersSummary && (
+                              <>
+                                <br />({clientCertFiltersSummary})
+                              </>
+                            )}
+                          </Typography>
+                        )}
+                        {connection?.clientCert?.info && (
+                          <Stack
+                            direction="row"
+                            alignItems="baseline"
+                            spacing={1}
+                          >
+                            <CertDetails
+                              open={showDetail}
+                              onClose={() => setShowDetail(false)}
+                              certInfo={connection?.clientCert?.info}
+                            />
+                            <Typography variant="subtitle2">File:</Typography>
+                            <Chip
+                              label="Details"
+                              color="primary"
+                              onClick={() => setShowDetail(true)}
+                            />
+                          </Stack>
+                        )}
+                      </Stack>
+                    </Grid>
+                  </Grid>
+                </Grid>
+              </AccordionDetails>
+            </Accordion>
+            <Accordion
+              sx={{
+                backgroundColor: 'background.paper',
+                marginTop: 2,
+                paddingLeft: 2,
+                paddingRight: 2,
+                borderRadius: 4,
+                '&:before': {
+                  display: 'none',
+                },
+              }}
+              square={false}
+            >
+              <AccordionSummary
+                expandIcon={<ChevronDown />}
+                aria-controls="log-content"
+                id="log-header"
+              >
+                <Grid container item alignItems="center">
+                  <Grid item xs={9}>
+                    <Typography variant="h5">Logs</Typography>
+                  </Grid>
+                  {!!logs?.length && (
+                    <Grid item xs={3}>
+                      <Button
+                        size="small"
+                        type="button"
+                        color="primary"
+                        disabled={!filteredLogs?.length}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          exportLogs();
+                        }}
+                      >
+                        Export Logs
+                      </Button>
+                      <IconButton
+                        aria-controls="filter-menu"
+                        aria-haspopup="true"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          toggleMenu(e);
+                        }}
+                        aria-label="Menu for filters/export"
+                        size="large"
+                      >
+                        <ExportJSON />
+                      </IconButton>
+                      <Menu
+                        id="filter-menu"
+                        anchorEl={menuAnchor}
+                        keepMounted
+                        open={Boolean(menuAnchor)}
+                        onClose={handleMenuClose}
+                      >
+                        <MenuItem
+                          key="errorFilter"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setErrorFilter(!errorFilter);
+                          }}
+                        >
+                          <Checkbox
+                            color="primary"
+                            checked={errorFilter}
+                            onChange={(e) => {
+                              e.stopPropagation();
+                              setErrorFilter(!errorFilter);
+                            }}
+                            value={errorFilter}
+                          />
+                          Error
+                        </MenuItem>
+                        <MenuItem
+                          key="infoFilter"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setInfoFilter(!infoFilter);
+                          }}
+                        >
+                          <Checkbox
+                            color="primary"
+                            checked={infoFilter}
+                            onChange={(e) => {
+                              e.stopPropagation();
+                              setInfoFilter(!infoFilter);
+                            }}
+                            value={infoFilter}
+                          />
+                          Info
+                        </MenuItem>
+                        <MenuItem key="exportToJSON">
+                          <Button
+                            size="small"
+                            type="button"
+                            color="primary"
+                            variant="contained"
+                            disabled={!filteredLogs?.length}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              exportLogs();
+                            }}
+                          >
+                            Export Logs
+                          </Button>
+                        </MenuItem>
+                      </Menu>
+                    </Grid>
+                  )}
+                </Grid>
+              </AccordionSummary>
+              <AccordionDetails>
+                <Grid container spacing={2}>
+                  {filteredLogs.map((log) => (
+                    <Grid
+                      item
+                      container
+                      alignItems="center"
+                      key={Math.random()}
+                      sx={{
+                        borderTop: '1px solid #E3E3E3',
+                      }}
+                    >
+                      <Grid item xs={2}>
+                        {log.status === 'info' && (
+                          <Info style={{ color: 'blue' }} />
+                        )}
+                        {log.status === 'error' && (
+                          <AlertTriangle style={{ color: 'orange' }} />
+                        )}
+                      </Grid>
+                      <Grid item xs={4}>
+                        <Typography>{log.date}</Typography>
+                      </Grid>
+                      <Grid item xs={6}>
+                        <Typography style={{ wordWrap: 'break-word' }}>
+                          {log.message}
+                        </Typography>
+                      </Grid>
+                    </Grid>
+                  ))}
+                </Grid>
+              </AccordionDetails>
+            </Accordion>
+            <Box minHeight="20px" />
+          </Stack>
         </Container>
       </>
     );

--- a/src/renderer/pages/LoadForm.tsx
+++ b/src/renderer/pages/LoadForm.tsx
@@ -96,7 +96,7 @@ async function reconcileConnections(
   await getAllRecords();
 }
 
-const LoadForm: FC = ({}) => {
+const LoadForm: FC = () => {
   const [serverUrl, setServerUrl] = useLocalStorage('LoadForm/serverUrl', '');
   const [connection, setConnection] = useLocalStorage(
     'LoadForm/connection',

--- a/src/renderer/pages/LoadForm.tsx
+++ b/src/renderer/pages/LoadForm.tsx
@@ -96,9 +96,7 @@ async function reconcileConnections(
   await getAllRecords();
 }
 
-export type LoadFormProps = {};
-
-const LoadForm: FC<LoadFormProps> = ({}) => {
+const LoadForm: FC = ({}) => {
   const [serverUrl, setServerUrl] = useLocalStorage('LoadForm/serverUrl', '');
   const [connection, setConnection] = useLocalStorage(
     'LoadForm/connection',

--- a/src/renderer/pages/LoadForm.tsx
+++ b/src/renderer/pages/LoadForm.tsx
@@ -1,0 +1,256 @@
+import {
+  Autocomplete,
+  Button,
+  CardContent,
+  Container,
+  FormControl,
+  FormControlLabel,
+  FormHelperText,
+  Stack,
+  Switch,
+  Typography,
+} from '@mui/material';
+import { ipcRenderer } from 'electron';
+import { defaults, isEqual } from 'lodash';
+import { enqueueSnackbar } from 'notistack';
+import React, { FC, useEffect } from 'react';
+import { useLocalStorage } from 'usehooks-ts';
+
+import {
+  DELETE,
+  FETCH_ROUTES,
+  FetchRoutesResponseArgs,
+  GET_ALL_RECORDS,
+  GetRecordsResponseArgs,
+  SAVE_RECORD,
+  TOAST_LENGTH,
+  VIEW_CONNECTION_LIST,
+} from '../../shared/constants';
+import {
+  Connection,
+  FetchRoutesRequest,
+  PortalRoute,
+  Protocol,
+  Record,
+} from '../../shared/pb/api';
+import AdvancedSettingsAccordion from '../components/AdvancedSettingsAccordion';
+import ClientCertSelection from '../components/ClientCertSelection';
+import StyledCard from '../components/StyledCard';
+import TagSelector from '../components/TagSelector';
+import TextField from '../components/TextField';
+
+function portalRouteToRecord(
+  baseRecord: Record,
+  portalRoute: PortalRoute,
+): Record {
+  const from = new URL(
+    portalRoute.from.replace(/^(udp[+])|(tcp[+])(.*?)$/, '$3'),
+  );
+  const remoteAddr =
+    from.pathname === '/' ? from.host : from.pathname.substring(1);
+  const pomeriumUrl = from.pathname === '/' ? undefined : from.toString();
+
+  return defaults(
+    {
+      source: `portal-route-${portalRoute.id}`,
+      conn: {
+        name: portalRoute.name,
+        protocol: portalRoute.type === 'tcp' ? Protocol.TCP : Protocol.UDP,
+        remoteAddr,
+        pomeriumUrl,
+      },
+    },
+    baseRecord,
+  );
+}
+
+function reconcileConnections(baseRecord: Record, portalRoutes: PortalRoute[]) {
+  ipcRenderer.once(GET_ALL_RECORDS, (_, args) => {
+    const { err, res }: GetRecordsResponseArgs = args;
+    if (err) {
+      enqueueSnackbar(err.message, {
+        variant: 'error',
+        autoHideDuration: TOAST_LENGTH,
+      });
+      return;
+    }
+
+    const currentRecords = new Map<string, Record>(
+      res?.records
+        ?.filter((r) => r.source?.startsWith('portal-route-'))
+        ?.map((r) => [r.source || '', r]) || [],
+    );
+    const newRecords = new Map<string, Record>(
+      portalRoutes
+        ?.filter((pr) => pr.type === 'tcp' || pr.type === 'udp')
+        ?.map((pr) => portalRouteToRecord(baseRecord, pr))
+        ?.map((r) => [r.source || '', r]) || [],
+    );
+
+    // remove current records which have been deleted
+    for (const [k, r] of currentRecords) {
+      if (!newRecords.has(k)) {
+        ipcRenderer.send(DELETE, {
+          ids: [r.id],
+        });
+      }
+    }
+
+    // add or update new records which have changed
+    for (const [k, r] of newRecords) {
+      const cr = currentRecords.get(k);
+      if (!cr) {
+        ipcRenderer.send(SAVE_RECORD, r);
+        return;
+      }
+      const nr = defaults(r, cr);
+      if (!isEqual(nr, cr)) {
+        ipcRenderer.send(SAVE_RECORD, nr);
+      }
+    }
+  });
+  ipcRenderer.send(GET_ALL_RECORDS);
+}
+
+export type LoadFormProps = {};
+
+const LoadForm: FC<LoadFormProps> = ({}) => {
+  const [serverUrl, setServerUrl] = useLocalStorage('LoadForm/serverUrl', '');
+  const [connection, setConnection] = useLocalStorage(
+    'LoadForm/connection',
+    (): Connection => {
+      return {
+        remoteAddr: '',
+      };
+    },
+  );
+  const [tags, setTags] = useLocalStorage('LoadForm/tags', (): string[] => []);
+
+  const onChangeUrl = (evt: React.ChangeEvent<HTMLInputElement>) => {
+    setServerUrl(evt.target.value);
+  };
+  const onClickBack = (evt: React.MouseEvent) => {
+    evt.preventDefault();
+    ipcRenderer.send(VIEW_CONNECTION_LIST);
+  };
+  const onClickLoad = (evt: React.MouseEvent) => {
+    evt.preventDefault();
+
+    if (serverUrl) {
+      const req: FetchRoutesRequest = {
+        serverUrl,
+        disableTlsVerification: connection.disableTlsVerification,
+        caCert: connection.caCert,
+        clientCert: connection.clientCert,
+        clientCertFromStore: connection.clientCertFromStore,
+      };
+      ipcRenderer.once(FETCH_ROUTES, (_, args) => {
+        const { err, res }: FetchRoutesResponseArgs = args;
+        if (err) {
+          enqueueSnackbar(err.message, {
+            variant: 'error',
+            autoHideDuration: TOAST_LENGTH,
+          });
+          return;
+        }
+        reconcileConnections(
+          {
+            tags,
+            conn: connection,
+          },
+          res?.routes || [],
+        );
+      });
+      ipcRenderer.send(FETCH_ROUTES, req);
+    }
+  };
+  const onSubmit = (evt: React.FormEvent) => {
+    evt.preventDefault();
+  };
+  const onToggleDisableTlsVerification = () => {
+    setConnection({
+      ...connection,
+      disableTlsVerification: connection?.disableTlsVerification
+        ? undefined
+        : true,
+    });
+  };
+
+  return (
+    <>
+      <Container maxWidth={false} sx={{ pt: 3 }}>
+        <form onSubmit={onSubmit}>
+          <Stack spacing={3}>
+            <Typography variant="h3" color="textPrimary">
+              Load Connections
+            </Typography>
+            <StyledCard>
+              <CardContent>
+                <TextField
+                  fullWidth
+                  required
+                  label="Pomerium URL"
+                  value={serverUrl}
+                  onChange={onChangeUrl}
+                  variant="outlined"
+                  autoFocus
+                  helperText="URL of a Pomerium Instance"
+                />
+                <TagSelector tags={tags} onChangeTags={setTags} />
+              </CardContent>
+            </StyledCard>
+            <AdvancedSettingsAccordion>
+              <Stack spacing={2}>
+                <FormControl>
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        checked={!!connection?.disableTlsVerification}
+                        name="disable-tls-verification"
+                        color="primary"
+                        onChange={onToggleDisableTlsVerification}
+                      />
+                    }
+                    label="Disable TLS Verification"
+                  />
+                  <FormHelperText sx={{ pl: 2 }}>
+                    Skips TLS verification. No Cert Authority Needed.
+                  </FormHelperText>
+                </FormControl>
+                <FormControl>
+                  <Typography sx={{ fontWeight: 500, pt: 1 }}>
+                    Client certificates
+                  </Typography>
+                  <ClientCertSelection
+                    connection={connection}
+                    onChangeConnection={setConnection}
+                  />
+                </FormControl>
+              </Stack>
+            </AdvancedSettingsAccordion>
+            <Stack direction="row" spacing={2} justifyContent="flex-end">
+              <Button
+                type="button"
+                variant="contained"
+                color="secondary"
+                onClick={onClickBack}
+              >
+                Back
+              </Button>
+              <Button
+                type="button"
+                variant="contained"
+                color="primary"
+                disabled={!serverUrl}
+                onClick={onClickLoad}
+              >
+                Load
+              </Button>
+            </Stack>
+          </Stack>
+        </form>
+      </Container>
+    </>
+  );
+};
+export default LoadForm;

--- a/src/renderer/pages/LoadForm.tsx
+++ b/src/renderer/pages/LoadForm.tsx
@@ -1,5 +1,4 @@
 import {
-  Autocomplete,
   Button,
   CardContent,
   Container,
@@ -11,29 +10,18 @@ import {
   Typography,
 } from '@mui/material';
 import { ipcRenderer } from 'electron';
-import { defaults, isEqual } from 'lodash';
+import { defaultsDeep, isEqual } from 'lodash';
 import { enqueueSnackbar } from 'notistack';
-import React, { FC, useEffect, useState } from 'react';
+import React, { FC, useState } from 'react';
 import { useLocalStorage } from 'usehooks-ts';
 
 import {
   DELETE,
-  FETCH_ROUTES,
-  FetchRoutesResponseArgs,
-  GET_ALL_RECORDS,
-  GetRecordsResponseArgs,
-  SAVE_RECORD,
   TOAST_LENGTH,
   VIEW_CONNECTION_LIST,
 } from '../../shared/constants';
 import { fetchRoutes, getAllRecords, saveRecord } from '../../shared/ipc';
-import {
-  Connection,
-  FetchRoutesRequest,
-  PortalRoute,
-  Protocol,
-  Record,
-} from '../../shared/pb/api';
+import { Connection, PortalRoute, Protocol, Record } from '../../shared/pb/api';
 import AdvancedSettingsAccordion from '../components/AdvancedSettingsAccordion';
 import ClientCertSelection from '../components/ClientCertSelection';
 import StyledCard from '../components/StyledCard';
@@ -51,7 +39,7 @@ function portalRouteToRecord(
     from.pathname === '/' ? from.host : from.pathname.substring(1);
   const pomeriumUrl = from.pathname === '/' ? undefined : from.toString();
 
-  return defaults(
+  return defaultsDeep(
     {
       source: `portal-route-${portalRoute.id}`,
       conn: {
@@ -97,9 +85,9 @@ async function reconcileConnections(
     const cr = currentRecords.get(k);
     if (!cr) {
       await saveRecord(r);
-      return;
+      continue;
     }
-    const nr = defaults(r, cr);
+    const nr = defaultsDeep(r, cr);
     if (!isEqual(nr, cr)) {
       await saveRecord(nr);
     }
@@ -176,25 +164,27 @@ const LoadForm: FC<LoadFormProps> = ({}) => {
 
   return (
     <>
-      <Container maxWidth={false} sx={{ pt: 3 }}>
+      <Container maxWidth={false} sx={{ pt: 4 }}>
         <form onSubmit={onSubmit}>
-          <Stack spacing={3}>
+          <Stack spacing={2}>
             <Typography variant="h3" color="textPrimary">
               Load Connections
             </Typography>
             <StyledCard>
               <CardContent>
-                <TextField
-                  fullWidth
-                  required
-                  label="Pomerium URL"
-                  value={serverUrl}
-                  onChange={onChangeUrl}
-                  variant="outlined"
-                  autoFocus
-                  helperText="URL of a Pomerium Instance"
-                />
-                <TagSelector tags={tags} onChangeTags={setTags} />
+                <Stack spacing={2}>
+                  <TextField
+                    fullWidth
+                    required
+                    label="Pomerium URL"
+                    value={serverUrl}
+                    onChange={onChangeUrl}
+                    variant="outlined"
+                    autoFocus
+                    helperText="URL of a Pomerium Instance"
+                  />
+                  <TagSelector tags={tags} onChangeTags={setTags} />
+                </Stack>
               </CardContent>
             </StyledCard>
             <AdvancedSettingsAccordion>

--- a/src/renderer/pages/ManageConnections.tsx
+++ b/src/renderer/pages/ManageConnections.tsx
@@ -9,8 +9,7 @@ import {
 import { ipcRenderer } from 'electron';
 import { useSnackbar } from 'notistack';
 import React, { ReactElement, useEffect, useState } from 'react';
-import { Save, Plus, Upload } from 'react-feather';
-import { Link } from 'react-router-dom';
+import { Save, Upload } from 'react-feather';
 
 import {
   DELETE,

--- a/src/renderer/pages/ManageConnections.tsx
+++ b/src/renderer/pages/ManageConnections.tsx
@@ -3,6 +3,7 @@ import {
   CardContent,
   Container,
   Grid,
+  Stack,
   Typography,
 } from '@mui/material';
 import { ipcRenderer } from 'electron';
@@ -32,6 +33,7 @@ import ConnectionRow from '../components/ConnectionRow';
 import ExportDialog, {
   IpcRendererEventListener,
 } from '../components/ExportDialog';
+import NewConnectionButton from '../components/NewConnectionButton';
 import StyledCard from '../components/StyledCard';
 import TagFolderRow from '../components/TagFolderRow';
 import VirtualFolderRow from '../components/VirtualFolderRow';
@@ -174,134 +176,127 @@ function ManageConnections(): ReactElement {
         exportFile={exportFile}
         onClose={() => setExportFile(null)}
       />
-      <Container maxWidth={false}>
-        <Grid sx={{ pt: 4 }}>
-          <Grid container alignItems="flex-start">
-            <Grid item xs={6}>
-              <Typography variant="h3" color="textPrimary">
-                Manage Connections
-              </Typography>
-            </Grid>
-            <Grid item xs={6} container justifyContent="flex-end">
-              <Grid item>
-                <Button
-                  type="button"
-                  color="primary"
-                  onClick={() => ipcRenderer.send(IMPORT)}
-                  endIcon={<Upload />}
-                >
-                  Import
-                </Button>
+      <Container maxWidth={false} sx={{ pt: 4 }}>
+        <Stack spacing={2}>
+          <Grid>
+            <Grid container alignItems="flex-start">
+              <Grid item xs={6}>
+                <Typography variant="h3" color="textPrimary">
+                  Manage Connections
+                </Typography>
               </Grid>
-              <Grid item xs={1} />
-              {connections?.length > 0 && (
+              <Grid item xs={6} container justifyContent="flex-end">
                 <Grid item>
                   <Button
                     type="button"
                     color="primary"
-                    onClick={() =>
-                      setExportFile({
-                        filename: 'connections',
-                        selector: {
-                          all: true,
-                          ids: [],
-                          tags: [],
-                        },
-                      })
-                    }
-                    endIcon={<Save />}
+                    onClick={() => ipcRenderer.send(IMPORT)}
+                    endIcon={<Upload />}
                   >
-                    Export
+                    Import
                   </Button>
                 </Grid>
-              )}
-              {connections?.length > 0 && <Grid item xs={1} />}
-              <Grid item>
-                <Button
-                  type="button"
-                  variant="contained"
-                  component={Link}
-                  to="/connectForm"
-                  color="primary"
-                  endIcon={<Plus />}
-                >
-                  New Connection
-                </Button>
+                <Grid item xs={1} />
+                {connections?.length > 0 && (
+                  <Grid item>
+                    <Button
+                      type="button"
+                      color="primary"
+                      onClick={() =>
+                        setExportFile({
+                          filename: 'connections',
+                          selector: {
+                            all: true,
+                            ids: [],
+                            tags: [],
+                          },
+                        })
+                      }
+                      endIcon={<Save />}
+                    >
+                      Export
+                    </Button>
+                  </Grid>
+                )}
+                {connections?.length > 0 && <Grid item xs={1} />}
+                <Grid item>
+                  <NewConnectionButton />
+                </Grid>
               </Grid>
             </Grid>
           </Grid>
-        </Grid>
-        <StyledCard>
-          <CardContent>
-            {folderNames.map((folderName) => {
-              const folderConns = connections.filter(
-                (connection) => connection?.tags?.indexOf(folderName) >= 0,
-              );
-              return (
-                <TagFolderRow
-                  key={'folderRow' + folderName}
-                  folderName={folderName}
-                  connectedListeners={getConnectedCount(folderConns)}
-                  totalListeners={folderConns.length}
-                  connectionIds={folderConns.map((rec) => rec.id as string)}
-                >
-                  {folderConns.map((record) => {
-                    return (
-                      <ConnectionRow
-                        key={'connectionRow' + folderName + record.id}
-                        folderName={folderName}
-                        connection={record}
-                        connected={
-                          !!record?.id &&
-                          statuses[record.id as string]?.listening
-                        }
-                        port={statuses[record.id as string]?.listenAddr || ''}
-                      />
-                    );
-                  })}
-                </TagFolderRow>
-              );
-            })}
-            <VirtualFolderRow
-              folderName="All Connections"
-              totalListeners={connections.length}
-              connectedListeners={getConnectedCount(connections)}
-            >
-              {connections.map((record) => {
+          <StyledCard>
+            <CardContent>
+              {folderNames.map((folderName) => {
+                const folderConns = connections.filter(
+                  (connection) => connection?.tags?.indexOf(folderName) >= 0,
+                );
                 return (
-                  <ConnectionRow
-                    key={'connectionRowAllConnections' + record.id}
-                    folderName="All Connections"
-                    connection={record}
-                    connected={
-                      !!record?.id && statuses[record.id as string]?.listening
-                    }
-                    port={statuses[record.id as string]?.listenAddr || ''}
-                  />
+                  <TagFolderRow
+                    key={'folderRow' + folderName}
+                    folderName={folderName}
+                    connectedListeners={getConnectedCount(folderConns)}
+                    totalListeners={folderConns.length}
+                    connectionIds={folderConns.map((rec) => rec.id as string)}
+                  >
+                    {folderConns.map((record) => {
+                      return (
+                        <ConnectionRow
+                          key={'connectionRow' + folderName + record.id}
+                          folderName={folderName}
+                          connection={record}
+                          connected={
+                            !!record?.id &&
+                            statuses[record.id as string]?.listening
+                          }
+                          port={statuses[record.id as string]?.listenAddr || ''}
+                        />
+                      );
+                    })}
+                  </TagFolderRow>
                 );
               })}
-            </VirtualFolderRow>
-            <VirtualFolderRow
-              folderName="Untagged"
-              totalListeners={untagged.length}
-              connectedListeners={getConnectedCount(untagged)}
-            >
-              {untagged.map((record) => {
-                return (
-                  <ConnectionRow
-                    key={'connectionRowUntagged' + record.id}
-                    folderName="Untagged"
-                    connection={record}
-                    connected={
-                      !!record?.id && statuses[record.id as string]?.listening
-                    }
-                    port={statuses[record.id as string]?.listenAddr || ''}
-                  />
-                );
-              })}
-            </VirtualFolderRow>
-          </CardContent>
-        </StyledCard>
+              <VirtualFolderRow
+                folderName="All Connections"
+                totalListeners={connections.length}
+                connectedListeners={getConnectedCount(connections)}
+              >
+                {connections.map((record) => {
+                  return (
+                    <ConnectionRow
+                      key={'connectionRowAllConnections' + record.id}
+                      folderName="All Connections"
+                      connection={record}
+                      connected={
+                        !!record?.id && statuses[record.id as string]?.listening
+                      }
+                      port={statuses[record.id as string]?.listenAddr || ''}
+                    />
+                  );
+                })}
+              </VirtualFolderRow>
+              <VirtualFolderRow
+                folderName="Untagged"
+                totalListeners={untagged.length}
+                connectedListeners={getConnectedCount(untagged)}
+              >
+                {untagged.map((record) => {
+                  return (
+                    <ConnectionRow
+                      key={'connectionRowUntagged' + record.id}
+                      folderName="Untagged"
+                      connection={record}
+                      connected={
+                        !!record?.id && statuses[record.id as string]?.listening
+                      }
+                      port={statuses[record.id as string]?.listenAddr || ''}
+                    />
+                  );
+                })}
+              </VirtualFolderRow>
+            </CardContent>
+          </StyledCard>
+        </Stack>
       </Container>
     </>
   );

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,6 +1,6 @@
 import { ServiceError } from '@grpc/grpc-js';
 
-import { FetchRoutesResponse, Records, Selector } from './pb/api';
+import { Records, Selector } from './pb/api';
 
 export const isProd = process.env.NODE_ENV === 'production';
 export const isDev = process.env.NODE_ENV === 'development';

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,4 +1,6 @@
-import { Selector } from './pb/api';
+import { ServiceError } from '@grpc/grpc-js';
+
+import { FetchRoutesResponse, Records, Selector } from './pb/api';
 
 export const isProd = process.env.NODE_ENV === 'production';
 export const isDev = process.env.NODE_ENV === 'development';
@@ -7,25 +9,26 @@ export const prodDebug = process.env.DEBUG_PROD === 'true';
 export const TOAST_LENGTH = 2000;
 
 // Actions for the ipcMain and ipcRenderer messages
-export const DISCONNECT_ALL = 'disconnect-all';
-export const DISCONNECT = 'disconnect';
-export const UPDATE_LISTENERS = 'update_listeners';
-export const LISTENER_STATUS = 'listener_status';
-export const LISTENER_LOG = 'listener_log';
-export const CONNECT_ALL = 'connect-all';
 export const CONNECT = 'connect';
-export const SAVE_RECORD = 'save_record';
-export const GET_RECORDS = 'get_records';
-export const GET_ALL_RECORDS = 'get_all_records';
-export const GET_UNIQUE_TAGS = 'get_tags';
-export const EDIT = 'edit';
-export const VIEW = 'view';
-export const VIEW_CONNECTION_LIST = 'view-connection-list';
+export const CONNECT_ALL = 'connect-all';
 export const DELETE = 'delete';
 export const DELETE_ALL = 'delete-all';
+export const DISCONNECT = 'disconnect';
+export const DISCONNECT_ALL = 'disconnect-all';
 export const DUPLICATE = 'duplicate';
+export const EDIT = 'edit';
 export const EXPORT = 'export';
+export const FETCH_ROUTES = 'fetch-routes';
+export const GET_ALL_RECORDS = 'get_all_records';
+export const GET_RECORDS = 'get_records';
+export const GET_UNIQUE_TAGS = 'get_tags';
 export const IMPORT = 'import';
+export const LISTENER_LOG = 'listener_log';
+export const LISTENER_STATUS = 'listener_status';
+export const SAVE_RECORD = 'save_record';
+export const UPDATE_LISTENERS = 'update_listeners';
+export const VIEW = 'view';
+export const VIEW_CONNECTION_LIST = 'view-connection-list';
 
 export interface ExportFile {
   selector: Selector;
@@ -49,3 +52,13 @@ export const THEMES = {
   LIGHT: 'LIGHT',
   DARK: 'DARK',
 };
+
+export interface FetchRoutesResponseArgs {
+  err?: ServiceError | null;
+  res?: FetchRoutesResponse;
+}
+
+export interface GetRecordsResponseArgs {
+  err?: ServiceError | null;
+  res?: Records;
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -53,11 +53,6 @@ export const THEMES = {
   DARK: 'DARK',
 };
 
-export interface FetchRoutesResponseArgs {
-  err?: ServiceError | null;
-  res?: FetchRoutesResponse;
-}
-
 export interface GetRecordsResponseArgs {
   err?: ServiceError | null;
   res?: Records;

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -10,8 +10,8 @@ import {
 
 function invoke(name: string, ...args: any[]): Promise<any> {
   return new Promise((resolve, reject) => {
-    ipcRenderer.once(name, (_evt, args) => {
-      const { res, err } = args;
+    ipcRenderer.once(name, (_evt, result) => {
+      const { res, err } = result;
       if (err) {
         reject(err);
       } else {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -1,0 +1,37 @@
+import { ipcRenderer } from 'electron';
+
+import { FETCH_ROUTES, GET_ALL_RECORDS, SAVE_RECORD } from './constants';
+import {
+  FetchRoutesRequest,
+  FetchRoutesResponse,
+  Record,
+  Records,
+} from './pb/api';
+
+function invoke(name: string, ...args: any[]): Promise<any> {
+  return new Promise((resolve, reject) => {
+    ipcRenderer.once(name, (_evt, args) => {
+      const { res, err } = args;
+      if (err) {
+        reject(err);
+      } else {
+        resolve(res);
+      }
+    });
+    ipcRenderer.send(name, ...args);
+  });
+}
+
+export async function fetchRoutes(
+  request: FetchRoutesRequest,
+): Promise<FetchRoutesResponse> {
+  return invoke(FETCH_ROUTES, request);
+}
+
+export async function getAllRecords(): Promise<Records> {
+  return invoke(GET_ALL_RECORDS);
+}
+
+export async function saveRecord(record: Record): Promise<Record> {
+  return invoke(SAVE_RECORD, record);
+}

--- a/src/shared/pb/api.ts
+++ b/src/shared/pb/api.ts
@@ -1,23 +1,65 @@
 /* eslint-disable */
 import {
-  makeGenericClientConstructor,
   ChannelCredentials,
-  ChannelOptions,
-  UntypedServiceImplementation,
-  handleUnaryCall,
   Client,
-  ClientUnaryCall,
-  Metadata,
-  CallOptions,
-  handleServerStreamingCall,
   ClientReadableStream,
-  ServiceError,
+  handleServerStreamingCall,
+  makeGenericClientConstructor,
+  Metadata,
 } from '@grpc/grpc-js';
-import { Timestamp } from './google/protobuf/timestamp';
+import type {
+  CallOptions,
+  ClientOptions,
+  ClientUnaryCall,
+  handleUnaryCall,
+  ServiceError,
+  UntypedServiceImplementation,
+} from '@grpc/grpc-js';
 import Long from 'long';
-import * as _m0 from 'protobufjs/minimal';
+import _m0 from 'protobufjs/minimal';
+
+import { Timestamp } from './google/protobuf/timestamp';
 
 export const protobufPackage = 'pomerium.cli';
+
+export enum Protocol {
+  UNKNOWN = 0,
+  TCP = 1,
+  UDP = 2,
+  UNRECOGNIZED = -1,
+}
+
+export function protocolFromJSON(object: any): Protocol {
+  switch (object) {
+    case 0:
+    case 'UNKNOWN':
+      return Protocol.UNKNOWN;
+    case 1:
+    case 'TCP':
+      return Protocol.TCP;
+    case 2:
+    case 'UDP':
+      return Protocol.UDP;
+    case -1:
+    case 'UNRECOGNIZED':
+    default:
+      return Protocol.UNRECOGNIZED;
+  }
+}
+
+export function protocolToJSON(object: Protocol): string {
+  switch (object) {
+    case Protocol.UNKNOWN:
+      return 'UNKNOWN';
+    case Protocol.TCP:
+      return 'TCP';
+    case Protocol.UDP:
+      return 'UDP';
+    case Protocol.UNRECOGNIZED:
+    default:
+      return 'UNRECOGNIZED';
+  }
+}
 
 /** Record represents a single tunnel record in the configuration */
 export interface Record {
@@ -26,6 +68,7 @@ export interface Record {
   tags: string[];
   /** connection data may be omitted if i.e. just manipulating the tags data */
   conn?: Connection | undefined;
+  source?: string | undefined;
 }
 
 export interface Records {
@@ -67,7 +110,7 @@ export enum ExportRequest_Format {
 }
 
 export function exportRequest_FormatFromJSON(
-  object: any
+  object: any,
 ): ExportRequest_Format {
   switch (object) {
     case 0:
@@ -87,7 +130,7 @@ export function exportRequest_FormatFromJSON(
 }
 
 export function exportRequest_FormatToJSON(
-  object: ExportRequest_Format
+  object: ExportRequest_Format,
 ): string {
   switch (object) {
     case ExportRequest_Format.EXPORT_FORMAT_UNDEFINED:
@@ -151,6 +194,28 @@ export interface StatusUpdatesRequest {
   connectionId: string;
 }
 
+export interface FetchRoutesRequest {
+  serverUrl: string;
+  disableTlsVerification?: boolean | undefined;
+  caCert?: Uint8Array | undefined;
+  clientCert?: Certificate | undefined;
+  clientCertFromStore?: ClientCertFromStore | undefined;
+}
+
+export interface FetchRoutesResponse {
+  routes: PortalRoute[];
+}
+
+export interface PortalRoute {
+  id: string;
+  name: string;
+  type: string;
+  from: string;
+  description: string;
+  connectCommand?: string | undefined;
+  logoUrl: string;
+}
+
 /** ConnectionStatusUpdates represent connection state changes */
 export interface ConnectionStatusUpdate {
   /** record this event relates to */
@@ -183,7 +248,7 @@ export enum ConnectionStatusUpdate_ConnectionStatus {
 }
 
 export function connectionStatusUpdate_ConnectionStatusFromJSON(
-  object: any
+  object: any,
 ): ConnectionStatusUpdate_ConnectionStatus {
   switch (object) {
     case 0:
@@ -215,7 +280,7 @@ export function connectionStatusUpdate_ConnectionStatusFromJSON(
 }
 
 export function connectionStatusUpdate_ConnectionStatusToJSON(
-  object: ConnectionStatusUpdate_ConnectionStatus
+  object: ConnectionStatusUpdate_ConnectionStatus,
 ): string {
   switch (object) {
     case ConnectionStatusUpdate_ConnectionStatus.CONNECTION_STATUS_UNDEFINED:
@@ -322,27 +387,29 @@ export interface ClientCertFromStore {
 export interface Connection {
   /** name is a user friendly connection name that a user may define */
   name?: string | undefined;
+  /** the protocol to use for the connection */
+  protocol?: Protocol | undefined;
   /** remote_addr is a remote pomerium host:port */
   remoteAddr: string;
   /** listen_address, if not provided, will assign a random port each time */
   listenAddr?: string | undefined;
   /** the URL of the pomerium server to connect to */
   pomeriumUrl?: string | undefined;
-  disableTlsVerification: boolean | undefined;
-  caCert: Uint8Array | undefined;
+  disableTlsVerification?: boolean | undefined;
+  caCert?: Uint8Array | undefined;
   clientCert?: Certificate | undefined;
   /** indicates to search the system trust store for a client certificate */
   clientCertFromStore?: ClientCertFromStore | undefined;
 }
 
 function createBaseRecord(): Record {
-  return { id: undefined, tags: [], conn: undefined };
+  return { id: undefined, tags: [], conn: undefined, source: undefined };
 }
 
 export const Record = {
   encode(
     message: Record,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.id !== undefined) {
       writer.uint32(10).string(message.id);
@@ -353,56 +420,90 @@ export const Record = {
     if (message.conn !== undefined) {
       Connection.encode(message.conn, writer.uint32(26).fork()).ldelim();
     }
+    if (message.source !== undefined) {
+      writer.uint32(34).string(message.source);
+    }
     return writer;
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): Record {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseRecord();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.id = reader.string();
-          break;
+          continue;
         case 2:
+          if (tag !== 18) {
+            break;
+          }
+
           message.tags.push(reader.string());
-          break;
+          continue;
         case 3:
+          if (tag !== 26) {
+            break;
+          }
+
           message.conn = Connection.decode(reader, reader.uint32());
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
+        case 4:
+          if (tag !== 34) {
+            break;
+          }
+
+          message.source = reader.string();
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
 
   fromJSON(object: any): Record {
     return {
-      id: isSet(object.id) ? String(object.id) : undefined,
-      tags: Array.isArray(object?.tags)
-        ? object.tags.map((e: any) => String(e))
+      id: isSet(object.id) ? globalThis.String(object.id) : undefined,
+      tags: globalThis.Array.isArray(object?.tags)
+        ? object.tags.map((e: any) => globalThis.String(e))
         : [],
       conn: isSet(object.conn) ? Connection.fromJSON(object.conn) : undefined,
+      source: isSet(object.source)
+        ? globalThis.String(object.source)
+        : undefined,
     };
   },
 
   toJSON(message: Record): unknown {
     const obj: any = {};
-    message.id !== undefined && (obj.id = message.id);
-    if (message.tags) {
-      obj.tags = message.tags.map((e) => e);
-    } else {
-      obj.tags = [];
+    if (message.id !== undefined) {
+      obj.id = message.id;
     }
-    message.conn !== undefined &&
-      (obj.conn = message.conn ? Connection.toJSON(message.conn) : undefined);
+    if (message.tags?.length) {
+      obj.tags = message.tags;
+    }
+    if (message.conn !== undefined) {
+      obj.conn = Connection.toJSON(message.conn);
+    }
+    if (message.source !== undefined) {
+      obj.source = message.source;
+    }
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Record>, I>>(base?: I): Record {
+    return Record.fromPartial(base ?? ({} as any));
+  },
   fromPartial<I extends Exact<DeepPartial<Record>, I>>(object: I): Record {
     const message = createBaseRecord();
     message.id = object.id ?? undefined;
@@ -411,6 +512,7 @@ export const Record = {
       object.conn !== undefined && object.conn !== null
         ? Connection.fromPartial(object.conn)
         : undefined;
+    message.source = object.source ?? undefined;
     return message;
   },
 };
@@ -422,7 +524,7 @@ function createBaseRecords(): Records {
 export const Records = {
   encode(
     message: Records,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     for (const v of message.records) {
       Record.encode(v!, writer.uint32(10).fork()).ldelim();
@@ -431,26 +533,32 @@ export const Records = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): Records {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseRecords();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.records.push(Record.decode(reader, reader.uint32()));
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
 
   fromJSON(object: any): Records {
     return {
-      records: Array.isArray(object?.records)
+      records: globalThis.Array.isArray(object?.records)
         ? object.records.map((e: any) => Record.fromJSON(e))
         : [],
     };
@@ -458,16 +566,15 @@ export const Records = {
 
   toJSON(message: Records): unknown {
     const obj: any = {};
-    if (message.records) {
-      obj.records = message.records.map((e) =>
-        e ? Record.toJSON(e) : undefined
-      );
-    } else {
-      obj.records = [];
+    if (message.records?.length) {
+      obj.records = message.records.map((e) => Record.toJSON(e));
     }
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Records>, I>>(base?: I): Records {
+    return Records.fromPartial(base ?? ({} as any));
+  },
   fromPartial<I extends Exact<DeepPartial<Records>, I>>(object: I): Records {
     const message = createBaseRecords();
     message.records = object.records?.map((e) => Record.fromPartial(e)) || [];
@@ -482,7 +589,7 @@ function createBaseSelector(): Selector {
 export const Selector = {
   encode(
     message: Selector,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.all === true) {
       writer.uint32(8).bool(message.all);
@@ -497,57 +604,72 @@ export const Selector = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): Selector {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseSelector();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 8) {
+            break;
+          }
+
           message.all = reader.bool();
-          break;
+          continue;
         case 2:
+          if (tag !== 18) {
+            break;
+          }
+
           message.ids.push(reader.string());
-          break;
+          continue;
         case 3:
+          if (tag !== 26) {
+            break;
+          }
+
           message.tags.push(reader.string());
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
 
   fromJSON(object: any): Selector {
     return {
-      all: isSet(object.all) ? Boolean(object.all) : false,
-      ids: Array.isArray(object?.ids)
-        ? object.ids.map((e: any) => String(e))
+      all: isSet(object.all) ? globalThis.Boolean(object.all) : false,
+      ids: globalThis.Array.isArray(object?.ids)
+        ? object.ids.map((e: any) => globalThis.String(e))
         : [],
-      tags: Array.isArray(object?.tags)
-        ? object.tags.map((e: any) => String(e))
+      tags: globalThis.Array.isArray(object?.tags)
+        ? object.tags.map((e: any) => globalThis.String(e))
         : [],
     };
   },
 
   toJSON(message: Selector): unknown {
     const obj: any = {};
-    message.all !== undefined && (obj.all = message.all);
-    if (message.ids) {
-      obj.ids = message.ids.map((e) => e);
-    } else {
-      obj.ids = [];
+    if (message.all === true) {
+      obj.all = message.all;
     }
-    if (message.tags) {
-      obj.tags = message.tags.map((e) => e);
-    } else {
-      obj.tags = [];
+    if (message.ids?.length) {
+      obj.ids = message.ids;
+    }
+    if (message.tags?.length) {
+      obj.tags = message.tags;
     }
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Selector>, I>>(base?: I): Selector {
+    return Selector.fromPartial(base ?? ({} as any));
+  },
   fromPartial<I extends Exact<DeepPartial<Selector>, I>>(object: I): Selector {
     const message = createBaseSelector();
     message.all = object.all ?? false;
@@ -564,25 +686,27 @@ function createBaseDeleteRecordsResponse(): DeleteRecordsResponse {
 export const DeleteRecordsResponse = {
   encode(
     _: DeleteRecordsResponse,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     return writer;
   },
 
   decode(
     input: _m0.Reader | Uint8Array,
-    length?: number
+    length?: number,
   ): DeleteRecordsResponse {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseDeleteRecordsResponse();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
-        default:
-          reader.skipType(tag & 7);
-          break;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -596,8 +720,13 @@ export const DeleteRecordsResponse = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<DeleteRecordsResponse>, I>>(
+    base?: I,
+  ): DeleteRecordsResponse {
+    return DeleteRecordsResponse.fromPartial(base ?? ({} as any));
+  },
   fromPartial<I extends Exact<DeepPartial<DeleteRecordsResponse>, I>>(
-    _: I
+    _: I,
   ): DeleteRecordsResponse {
     const message = createBaseDeleteRecordsResponse();
     return message;
@@ -611,7 +740,7 @@ function createBaseExportRequest(): ExportRequest {
 export const ExportRequest = {
   encode(
     message: ExportRequest,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.selector !== undefined) {
       Selector.encode(message.selector, writer.uint32(10).fork()).ldelim();
@@ -626,25 +755,39 @@ export const ExportRequest = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): ExportRequest {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseExportRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.selector = Selector.decode(reader, reader.uint32());
-          break;
+          continue;
         case 2:
+          if (tag !== 16) {
+            break;
+          }
+
           message.removeTags = reader.bool();
-          break;
+          continue;
         case 3:
+          if (tag !== 24) {
+            break;
+          }
+
           message.format = reader.int32() as any;
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -654,7 +797,9 @@ export const ExportRequest = {
       selector: isSet(object.selector)
         ? Selector.fromJSON(object.selector)
         : undefined,
-      removeTags: isSet(object.removeTags) ? Boolean(object.removeTags) : false,
+      removeTags: isSet(object.removeTags)
+        ? globalThis.Boolean(object.removeTags)
+        : false,
       format: isSet(object.format)
         ? exportRequest_FormatFromJSON(object.format)
         : 0,
@@ -663,18 +808,25 @@ export const ExportRequest = {
 
   toJSON(message: ExportRequest): unknown {
     const obj: any = {};
-    message.selector !== undefined &&
-      (obj.selector = message.selector
-        ? Selector.toJSON(message.selector)
-        : undefined);
-    message.removeTags !== undefined && (obj.removeTags = message.removeTags);
-    message.format !== undefined &&
-      (obj.format = exportRequest_FormatToJSON(message.format));
+    if (message.selector !== undefined) {
+      obj.selector = Selector.toJSON(message.selector);
+    }
+    if (message.removeTags === true) {
+      obj.removeTags = message.removeTags;
+    }
+    if (message.format !== 0) {
+      obj.format = exportRequest_FormatToJSON(message.format);
+    }
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<ExportRequest>, I>>(
+    base?: I,
+  ): ExportRequest {
+    return ExportRequest.fromPartial(base ?? ({} as any));
+  },
   fromPartial<I extends Exact<DeepPartial<ExportRequest>, I>>(
-    object: I
+    object: I,
   ): ExportRequest {
     const message = createBaseExportRequest();
     message.selector =
@@ -694,22 +846,24 @@ function createBaseGetTagsRequest(): GetTagsRequest {
 export const GetTagsRequest = {
   encode(
     _: GetTagsRequest,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     return writer;
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): GetTagsRequest {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseGetTagsRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
-        default:
-          reader.skipType(tag & 7);
-          break;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -723,8 +877,13 @@ export const GetTagsRequest = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<GetTagsRequest>, I>>(
+    base?: I,
+  ): GetTagsRequest {
+    return GetTagsRequest.fromPartial(base ?? ({} as any));
+  },
   fromPartial<I extends Exact<DeepPartial<GetTagsRequest>, I>>(
-    _: I
+    _: I,
   ): GetTagsRequest {
     const message = createBaseGetTagsRequest();
     return message;
@@ -738,7 +897,7 @@ function createBaseGetTagsResponse(): GetTagsResponse {
 export const GetTagsResponse = {
   encode(
     message: GetTagsResponse,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     for (const v of message.tags) {
       writer.uint32(10).string(v!);
@@ -747,43 +906,52 @@ export const GetTagsResponse = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): GetTagsResponse {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseGetTagsResponse();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.tags.push(reader.string());
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
 
   fromJSON(object: any): GetTagsResponse {
     return {
-      tags: Array.isArray(object?.tags)
-        ? object.tags.map((e: any) => String(e))
+      tags: globalThis.Array.isArray(object?.tags)
+        ? object.tags.map((e: any) => globalThis.String(e))
         : [],
     };
   },
 
   toJSON(message: GetTagsResponse): unknown {
     const obj: any = {};
-    if (message.tags) {
-      obj.tags = message.tags.map((e) => e);
-    } else {
-      obj.tags = [];
+    if (message.tags?.length) {
+      obj.tags = message.tags;
     }
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<GetTagsResponse>, I>>(
+    base?: I,
+  ): GetTagsResponse {
+    return GetTagsResponse.fromPartial(base ?? ({} as any));
+  },
   fromPartial<I extends Exact<DeepPartial<GetTagsResponse>, I>>(
-    object: I
+    object: I,
   ): GetTagsResponse {
     const message = createBaseGetTagsResponse();
     message.tags = object.tags?.map((e) => e) || [];
@@ -792,13 +960,13 @@ export const GetTagsResponse = {
 };
 
 function createBaseConfigData(): ConfigData {
-  return { data: new Uint8Array() };
+  return { data: new Uint8Array(0) };
 }
 
 export const ConfigData = {
   encode(
     message: ConfigData,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.data.length !== 0) {
       writer.uint32(10).bytes(message.data);
@@ -807,19 +975,25 @@ export const ConfigData = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): ConfigData {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseConfigData();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.data = reader.bytes();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -828,36 +1002,38 @@ export const ConfigData = {
     return {
       data: isSet(object.data)
         ? bytesFromBase64(object.data)
-        : new Uint8Array(),
+        : new Uint8Array(0),
     };
   },
 
   toJSON(message: ConfigData): unknown {
     const obj: any = {};
-    message.data !== undefined &&
-      (obj.data = base64FromBytes(
-        message.data !== undefined ? message.data : new Uint8Array()
-      ));
+    if (message.data.length !== 0) {
+      obj.data = base64FromBytes(message.data);
+    }
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<ConfigData>, I>>(base?: I): ConfigData {
+    return ConfigData.fromPartial(base ?? ({} as any));
+  },
   fromPartial<I extends Exact<DeepPartial<ConfigData>, I>>(
-    object: I
+    object: I,
   ): ConfigData {
     const message = createBaseConfigData();
-    message.data = object.data ?? new Uint8Array();
+    message.data = object.data ?? new Uint8Array(0);
     return message;
   },
 };
 
 function createBaseImportRequest(): ImportRequest {
-  return { overrideTag: undefined, data: new Uint8Array() };
+  return { overrideTag: undefined, data: new Uint8Array(0) };
 }
 
 export const ImportRequest = {
   encode(
     message: ImportRequest,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.overrideTag !== undefined) {
       writer.uint32(10).string(message.overrideTag);
@@ -869,22 +1045,32 @@ export const ImportRequest = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): ImportRequest {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseImportRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.overrideTag = reader.string();
-          break;
+          continue;
         case 2:
+          if (tag !== 18) {
+            break;
+          }
+
           message.data = reader.bytes();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -892,31 +1078,36 @@ export const ImportRequest = {
   fromJSON(object: any): ImportRequest {
     return {
       overrideTag: isSet(object.overrideTag)
-        ? String(object.overrideTag)
+        ? globalThis.String(object.overrideTag)
         : undefined,
       data: isSet(object.data)
         ? bytesFromBase64(object.data)
-        : new Uint8Array(),
+        : new Uint8Array(0),
     };
   },
 
   toJSON(message: ImportRequest): unknown {
     const obj: any = {};
-    message.overrideTag !== undefined &&
-      (obj.overrideTag = message.overrideTag);
-    message.data !== undefined &&
-      (obj.data = base64FromBytes(
-        message.data !== undefined ? message.data : new Uint8Array()
-      ));
+    if (message.overrideTag !== undefined) {
+      obj.overrideTag = message.overrideTag;
+    }
+    if (message.data.length !== 0) {
+      obj.data = base64FromBytes(message.data);
+    }
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<ImportRequest>, I>>(
+    base?: I,
+  ): ImportRequest {
+    return ImportRequest.fromPartial(base ?? ({} as any));
+  },
   fromPartial<I extends Exact<DeepPartial<ImportRequest>, I>>(
-    object: I
+    object: I,
   ): ImportRequest {
     const message = createBaseImportRequest();
     message.overrideTag = object.overrideTag ?? undefined;
-    message.data = object.data ?? new Uint8Array();
+    message.data = object.data ?? new Uint8Array(0);
     return message;
   },
 };
@@ -928,22 +1119,24 @@ function createBaseImportResponse(): ImportResponse {
 export const ImportResponse = {
   encode(
     _: ImportResponse,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     return writer;
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): ImportResponse {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseImportResponse();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
-        default:
-          reader.skipType(tag & 7);
-          break;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -957,8 +1150,13 @@ export const ImportResponse = {
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<ImportResponse>, I>>(
+    base?: I,
+  ): ImportResponse {
+    return ImportResponse.fromPartial(base ?? ({} as any));
+  },
   fromPartial<I extends Exact<DeepPartial<ImportResponse>, I>>(
-    _: I
+    _: I,
   ): ImportResponse {
     const message = createBaseImportResponse();
     return message;
@@ -972,7 +1170,7 @@ function createBaseListenerUpdateRequest(): ListenerUpdateRequest {
 export const ListenerUpdateRequest = {
   encode(
     message: ListenerUpdateRequest,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     for (const v of message.connectionIds) {
       writer.uint32(10).string(v!);
@@ -985,50 +1183,67 @@ export const ListenerUpdateRequest = {
 
   decode(
     input: _m0.Reader | Uint8Array,
-    length?: number
+    length?: number,
   ): ListenerUpdateRequest {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseListenerUpdateRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.connectionIds.push(reader.string());
-          break;
+          continue;
         case 2:
+          if (tag !== 16) {
+            break;
+          }
+
           message.connected = reader.bool();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
 
   fromJSON(object: any): ListenerUpdateRequest {
     return {
-      connectionIds: Array.isArray(object?.connectionIds)
-        ? object.connectionIds.map((e: any) => String(e))
+      connectionIds: globalThis.Array.isArray(object?.connectionIds)
+        ? object.connectionIds.map((e: any) => globalThis.String(e))
         : [],
-      connected: isSet(object.connected) ? Boolean(object.connected) : false,
+      connected: isSet(object.connected)
+        ? globalThis.Boolean(object.connected)
+        : false,
     };
   },
 
   toJSON(message: ListenerUpdateRequest): unknown {
     const obj: any = {};
-    if (message.connectionIds) {
-      obj.connectionIds = message.connectionIds.map((e) => e);
-    } else {
-      obj.connectionIds = [];
+    if (message.connectionIds?.length) {
+      obj.connectionIds = message.connectionIds;
     }
-    message.connected !== undefined && (obj.connected = message.connected);
+    if (message.connected === true) {
+      obj.connected = message.connected;
+    }
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<ListenerUpdateRequest>, I>>(
+    base?: I,
+  ): ListenerUpdateRequest {
+    return ListenerUpdateRequest.fromPartial(base ?? ({} as any));
+  },
   fromPartial<I extends Exact<DeepPartial<ListenerUpdateRequest>, I>>(
-    object: I
+    object: I,
   ): ListenerUpdateRequest {
     const message = createBaseListenerUpdateRequest();
     message.connectionIds = object.connectionIds?.map((e) => e) || [];
@@ -1044,7 +1259,7 @@ function createBaseListenerStatus(): ListenerStatus {
 export const ListenerStatus = {
   encode(
     message: ListenerStatus,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.listening === true) {
       writer.uint32(8).bool(message.listening);
@@ -1059,49 +1274,78 @@ export const ListenerStatus = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): ListenerStatus {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseListenerStatus();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 8) {
+            break;
+          }
+
           message.listening = reader.bool();
-          break;
+          continue;
         case 2:
+          if (tag !== 18) {
+            break;
+          }
+
           message.listenAddr = reader.string();
-          break;
+          continue;
         case 3:
+          if (tag !== 26) {
+            break;
+          }
+
           message.lastError = reader.string();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
 
   fromJSON(object: any): ListenerStatus {
     return {
-      listening: isSet(object.listening) ? Boolean(object.listening) : false,
+      listening: isSet(object.listening)
+        ? globalThis.Boolean(object.listening)
+        : false,
       listenAddr: isSet(object.listenAddr)
-        ? String(object.listenAddr)
+        ? globalThis.String(object.listenAddr)
         : undefined,
-      lastError: isSet(object.lastError) ? String(object.lastError) : undefined,
+      lastError: isSet(object.lastError)
+        ? globalThis.String(object.lastError)
+        : undefined,
     };
   },
 
   toJSON(message: ListenerStatus): unknown {
     const obj: any = {};
-    message.listening !== undefined && (obj.listening = message.listening);
-    message.listenAddr !== undefined && (obj.listenAddr = message.listenAddr);
-    message.lastError !== undefined && (obj.lastError = message.lastError);
+    if (message.listening === true) {
+      obj.listening = message.listening;
+    }
+    if (message.listenAddr !== undefined) {
+      obj.listenAddr = message.listenAddr;
+    }
+    if (message.lastError !== undefined) {
+      obj.lastError = message.lastError;
+    }
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<ListenerStatus>, I>>(
+    base?: I,
+  ): ListenerStatus {
+    return ListenerStatus.fromPartial(base ?? ({} as any));
+  },
   fromPartial<I extends Exact<DeepPartial<ListenerStatus>, I>>(
-    object: I
+    object: I,
   ): ListenerStatus {
     const message = createBaseListenerStatus();
     message.listening = object.listening ?? false;
@@ -1118,12 +1362,12 @@ function createBaseListenerStatusResponse(): ListenerStatusResponse {
 export const ListenerStatusResponse = {
   encode(
     message: ListenerStatusResponse,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     Object.entries(message.listeners).forEach(([key, value]) => {
       ListenerStatusResponse_ListenersEntry.encode(
         { key: key as any, value },
-        writer.uint32(10).fork()
+        writer.uint32(10).fork(),
       ).ldelim();
     });
     return writer;
@@ -1131,27 +1375,33 @@ export const ListenerStatusResponse = {
 
   decode(
     input: _m0.Reader | Uint8Array,
-    length?: number
+    length?: number,
   ): ListenerStatusResponse {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseListenerStatusResponse();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           const entry1 = ListenerStatusResponse_ListenersEntry.decode(
             reader,
-            reader.uint32()
+            reader.uint32(),
           );
           if (entry1.value !== undefined) {
             message.listeners[entry1.key] = entry1.value;
           }
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -1171,17 +1421,25 @@ export const ListenerStatusResponse = {
 
   toJSON(message: ListenerStatusResponse): unknown {
     const obj: any = {};
-    obj.listeners = {};
     if (message.listeners) {
-      Object.entries(message.listeners).forEach(([k, v]) => {
-        obj.listeners[k] = ListenerStatus.toJSON(v);
-      });
+      const entries = Object.entries(message.listeners);
+      if (entries.length > 0) {
+        obj.listeners = {};
+        entries.forEach(([k, v]) => {
+          obj.listeners[k] = ListenerStatus.toJSON(v);
+        });
+      }
     }
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<ListenerStatusResponse>, I>>(
+    base?: I,
+  ): ListenerStatusResponse {
+    return ListenerStatusResponse.fromPartial(base ?? ({} as any));
+  },
   fromPartial<I extends Exact<DeepPartial<ListenerStatusResponse>, I>>(
-    object: I
+    object: I,
   ): ListenerStatusResponse {
     const message = createBaseListenerStatusResponse();
     message.listeners = Object.entries(object.listeners ?? {}).reduce<{
@@ -1203,7 +1461,7 @@ function createBaseListenerStatusResponse_ListenersEntry(): ListenerStatusRespon
 export const ListenerStatusResponse_ListenersEntry = {
   encode(
     message: ListenerStatusResponse_ListenersEntry,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.key !== '') {
       writer.uint32(10).string(message.key);
@@ -1216,31 +1474,41 @@ export const ListenerStatusResponse_ListenersEntry = {
 
   decode(
     input: _m0.Reader | Uint8Array,
-    length?: number
+    length?: number,
   ): ListenerStatusResponse_ListenersEntry {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseListenerStatusResponse_ListenersEntry();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.key = reader.string();
-          break;
+          continue;
         case 2:
+          if (tag !== 18) {
+            break;
+          }
+
           message.value = ListenerStatus.decode(reader, reader.uint32());
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
 
   fromJSON(object: any): ListenerStatusResponse_ListenersEntry {
     return {
-      key: isSet(object.key) ? String(object.key) : '',
+      key: isSet(object.key) ? globalThis.String(object.key) : '',
       value: isSet(object.value)
         ? ListenerStatus.fromJSON(object.value)
         : undefined,
@@ -1249,16 +1517,24 @@ export const ListenerStatusResponse_ListenersEntry = {
 
   toJSON(message: ListenerStatusResponse_ListenersEntry): unknown {
     const obj: any = {};
-    message.key !== undefined && (obj.key = message.key);
-    message.value !== undefined &&
-      (obj.value = message.value
-        ? ListenerStatus.toJSON(message.value)
-        : undefined);
+    if (message.key !== '') {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = ListenerStatus.toJSON(message.value);
+    }
     return obj;
   },
 
+  create<
+    I extends Exact<DeepPartial<ListenerStatusResponse_ListenersEntry>, I>,
+  >(base?: I): ListenerStatusResponse_ListenersEntry {
+    return ListenerStatusResponse_ListenersEntry.fromPartial(
+      base ?? ({} as any),
+    );
+  },
   fromPartial<
-    I extends Exact<DeepPartial<ListenerStatusResponse_ListenersEntry>, I>
+    I extends Exact<DeepPartial<ListenerStatusResponse_ListenersEntry>, I>,
   >(object: I): ListenerStatusResponse_ListenersEntry {
     const message = createBaseListenerStatusResponse_ListenersEntry();
     message.key = object.key ?? '';
@@ -1277,7 +1553,7 @@ function createBaseStatusUpdatesRequest(): StatusUpdatesRequest {
 export const StatusUpdatesRequest = {
   encode(
     message: StatusUpdatesRequest,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.connectionId !== '') {
       writer.uint32(10).string(message.connectionId);
@@ -1287,21 +1563,27 @@ export const StatusUpdatesRequest = {
 
   decode(
     input: _m0.Reader | Uint8Array,
-    length?: number
+    length?: number,
   ): StatusUpdatesRequest {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseStatusUpdatesRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.connectionId = reader.string();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -1309,23 +1591,422 @@ export const StatusUpdatesRequest = {
   fromJSON(object: any): StatusUpdatesRequest {
     return {
       connectionId: isSet(object.connectionId)
-        ? String(object.connectionId)
+        ? globalThis.String(object.connectionId)
         : '',
     };
   },
 
   toJSON(message: StatusUpdatesRequest): unknown {
     const obj: any = {};
-    message.connectionId !== undefined &&
-      (obj.connectionId = message.connectionId);
+    if (message.connectionId !== '') {
+      obj.connectionId = message.connectionId;
+    }
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<StatusUpdatesRequest>, I>>(
+    base?: I,
+  ): StatusUpdatesRequest {
+    return StatusUpdatesRequest.fromPartial(base ?? ({} as any));
+  },
   fromPartial<I extends Exact<DeepPartial<StatusUpdatesRequest>, I>>(
-    object: I
+    object: I,
   ): StatusUpdatesRequest {
     const message = createBaseStatusUpdatesRequest();
     message.connectionId = object.connectionId ?? '';
+    return message;
+  },
+};
+
+function createBaseFetchRoutesRequest(): FetchRoutesRequest {
+  return {
+    serverUrl: '',
+    disableTlsVerification: undefined,
+    caCert: undefined,
+    clientCert: undefined,
+    clientCertFromStore: undefined,
+  };
+}
+
+export const FetchRoutesRequest = {
+  encode(
+    message: FetchRoutesRequest,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.serverUrl !== '') {
+      writer.uint32(10).string(message.serverUrl);
+    }
+    if (message.disableTlsVerification !== undefined) {
+      writer.uint32(16).bool(message.disableTlsVerification);
+    }
+    if (message.caCert !== undefined) {
+      writer.uint32(26).bytes(message.caCert);
+    }
+    if (message.clientCert !== undefined) {
+      Certificate.encode(message.clientCert, writer.uint32(34).fork()).ldelim();
+    }
+    if (message.clientCertFromStore !== undefined) {
+      ClientCertFromStore.encode(
+        message.clientCertFromStore,
+        writer.uint32(42).fork(),
+      ).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): FetchRoutesRequest {
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseFetchRoutesRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag !== 10) {
+            break;
+          }
+
+          message.serverUrl = reader.string();
+          continue;
+        case 2:
+          if (tag !== 16) {
+            break;
+          }
+
+          message.disableTlsVerification = reader.bool();
+          continue;
+        case 3:
+          if (tag !== 26) {
+            break;
+          }
+
+          message.caCert = reader.bytes();
+          continue;
+        case 4:
+          if (tag !== 34) {
+            break;
+          }
+
+          message.clientCert = Certificate.decode(reader, reader.uint32());
+          continue;
+        case 5:
+          if (tag !== 42) {
+            break;
+          }
+
+          message.clientCertFromStore = ClientCertFromStore.decode(
+            reader,
+            reader.uint32(),
+          );
+          continue;
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): FetchRoutesRequest {
+    return {
+      serverUrl: isSet(object.serverUrl)
+        ? globalThis.String(object.serverUrl)
+        : '',
+      disableTlsVerification: isSet(object.disableTlsVerification)
+        ? globalThis.Boolean(object.disableTlsVerification)
+        : undefined,
+      caCert: isSet(object.caCert) ? bytesFromBase64(object.caCert) : undefined,
+      clientCert: isSet(object.clientCert)
+        ? Certificate.fromJSON(object.clientCert)
+        : undefined,
+      clientCertFromStore: isSet(object.clientCertFromStore)
+        ? ClientCertFromStore.fromJSON(object.clientCertFromStore)
+        : undefined,
+    };
+  },
+
+  toJSON(message: FetchRoutesRequest): unknown {
+    const obj: any = {};
+    if (message.serverUrl !== '') {
+      obj.serverUrl = message.serverUrl;
+    }
+    if (message.disableTlsVerification !== undefined) {
+      obj.disableTlsVerification = message.disableTlsVerification;
+    }
+    if (message.caCert !== undefined) {
+      obj.caCert = base64FromBytes(message.caCert);
+    }
+    if (message.clientCert !== undefined) {
+      obj.clientCert = Certificate.toJSON(message.clientCert);
+    }
+    if (message.clientCertFromStore !== undefined) {
+      obj.clientCertFromStore = ClientCertFromStore.toJSON(
+        message.clientCertFromStore,
+      );
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<FetchRoutesRequest>, I>>(
+    base?: I,
+  ): FetchRoutesRequest {
+    return FetchRoutesRequest.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<FetchRoutesRequest>, I>>(
+    object: I,
+  ): FetchRoutesRequest {
+    const message = createBaseFetchRoutesRequest();
+    message.serverUrl = object.serverUrl ?? '';
+    message.disableTlsVerification = object.disableTlsVerification ?? undefined;
+    message.caCert = object.caCert ?? undefined;
+    message.clientCert =
+      object.clientCert !== undefined && object.clientCert !== null
+        ? Certificate.fromPartial(object.clientCert)
+        : undefined;
+    message.clientCertFromStore =
+      object.clientCertFromStore !== undefined &&
+      object.clientCertFromStore !== null
+        ? ClientCertFromStore.fromPartial(object.clientCertFromStore)
+        : undefined;
+    return message;
+  },
+};
+
+function createBaseFetchRoutesResponse(): FetchRoutesResponse {
+  return { routes: [] };
+}
+
+export const FetchRoutesResponse = {
+  encode(
+    message: FetchRoutesResponse,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    for (const v of message.routes) {
+      PortalRoute.encode(v!, writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): FetchRoutesResponse {
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseFetchRoutesResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag !== 10) {
+            break;
+          }
+
+          message.routes.push(PortalRoute.decode(reader, reader.uint32()));
+          continue;
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): FetchRoutesResponse {
+    return {
+      routes: globalThis.Array.isArray(object?.routes)
+        ? object.routes.map((e: any) => PortalRoute.fromJSON(e))
+        : [],
+    };
+  },
+
+  toJSON(message: FetchRoutesResponse): unknown {
+    const obj: any = {};
+    if (message.routes?.length) {
+      obj.routes = message.routes.map((e) => PortalRoute.toJSON(e));
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<FetchRoutesResponse>, I>>(
+    base?: I,
+  ): FetchRoutesResponse {
+    return FetchRoutesResponse.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<FetchRoutesResponse>, I>>(
+    object: I,
+  ): FetchRoutesResponse {
+    const message = createBaseFetchRoutesResponse();
+    message.routes =
+      object.routes?.map((e) => PortalRoute.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+function createBasePortalRoute(): PortalRoute {
+  return {
+    id: '',
+    name: '',
+    type: '',
+    from: '',
+    description: '',
+    connectCommand: undefined,
+    logoUrl: '',
+  };
+}
+
+export const PortalRoute = {
+  encode(
+    message: PortalRoute,
+    writer: _m0.Writer = _m0.Writer.create(),
+  ): _m0.Writer {
+    if (message.id !== '') {
+      writer.uint32(10).string(message.id);
+    }
+    if (message.name !== '') {
+      writer.uint32(18).string(message.name);
+    }
+    if (message.type !== '') {
+      writer.uint32(26).string(message.type);
+    }
+    if (message.from !== '') {
+      writer.uint32(34).string(message.from);
+    }
+    if (message.description !== '') {
+      writer.uint32(42).string(message.description);
+    }
+    if (message.connectCommand !== undefined) {
+      writer.uint32(50).string(message.connectCommand);
+    }
+    if (message.logoUrl !== '') {
+      writer.uint32(58).string(message.logoUrl);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): PortalRoute {
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBasePortalRoute();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag !== 10) {
+            break;
+          }
+
+          message.id = reader.string();
+          continue;
+        case 2:
+          if (tag !== 18) {
+            break;
+          }
+
+          message.name = reader.string();
+          continue;
+        case 3:
+          if (tag !== 26) {
+            break;
+          }
+
+          message.type = reader.string();
+          continue;
+        case 4:
+          if (tag !== 34) {
+            break;
+          }
+
+          message.from = reader.string();
+          continue;
+        case 5:
+          if (tag !== 42) {
+            break;
+          }
+
+          message.description = reader.string();
+          continue;
+        case 6:
+          if (tag !== 50) {
+            break;
+          }
+
+          message.connectCommand = reader.string();
+          continue;
+        case 7:
+          if (tag !== 58) {
+            break;
+          }
+
+          message.logoUrl = reader.string();
+          continue;
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): PortalRoute {
+    return {
+      id: isSet(object.id) ? globalThis.String(object.id) : '',
+      name: isSet(object.name) ? globalThis.String(object.name) : '',
+      type: isSet(object.type) ? globalThis.String(object.type) : '',
+      from: isSet(object.from) ? globalThis.String(object.from) : '',
+      description: isSet(object.description)
+        ? globalThis.String(object.description)
+        : '',
+      connectCommand: isSet(object.connectCommand)
+        ? globalThis.String(object.connectCommand)
+        : undefined,
+      logoUrl: isSet(object.logoUrl) ? globalThis.String(object.logoUrl) : '',
+    };
+  },
+
+  toJSON(message: PortalRoute): unknown {
+    const obj: any = {};
+    if (message.id !== '') {
+      obj.id = message.id;
+    }
+    if (message.name !== '') {
+      obj.name = message.name;
+    }
+    if (message.type !== '') {
+      obj.type = message.type;
+    }
+    if (message.from !== '') {
+      obj.from = message.from;
+    }
+    if (message.description !== '') {
+      obj.description = message.description;
+    }
+    if (message.connectCommand !== undefined) {
+      obj.connectCommand = message.connectCommand;
+    }
+    if (message.logoUrl !== '') {
+      obj.logoUrl = message.logoUrl;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<PortalRoute>, I>>(base?: I): PortalRoute {
+    return PortalRoute.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<PortalRoute>, I>>(
+    object: I,
+  ): PortalRoute {
+    const message = createBasePortalRoute();
+    message.id = object.id ?? '';
+    message.name = object.name ?? '';
+    message.type = object.type ?? '';
+    message.from = object.from ?? '';
+    message.description = object.description ?? '';
+    message.connectCommand = object.connectCommand ?? undefined;
+    message.logoUrl = object.logoUrl ?? '';
     return message;
   },
 };
@@ -1344,7 +2025,7 @@ function createBaseConnectionStatusUpdate(): ConnectionStatusUpdate {
 export const ConnectionStatusUpdate = {
   encode(
     message: ConnectionStatusUpdate,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.id !== '') {
       writer.uint32(10).string(message.id);
@@ -1364,7 +2045,7 @@ export const ConnectionStatusUpdate = {
     if (message.ts !== undefined) {
       Timestamp.encode(
         toTimestamp(message.ts),
-        writer.uint32(50).fork()
+        writer.uint32(50).fork(),
       ).ldelim();
     }
     return writer;
@@ -1372,69 +2053,117 @@ export const ConnectionStatusUpdate = {
 
   decode(
     input: _m0.Reader | Uint8Array,
-    length?: number
+    length?: number,
   ): ConnectionStatusUpdate {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseConnectionStatusUpdate();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.id = reader.string();
-          break;
+          continue;
         case 2:
+          if (tag !== 18) {
+            break;
+          }
+
           message.peerAddr = reader.string();
-          break;
+          continue;
         case 3:
+          if (tag !== 24) {
+            break;
+          }
+
           message.status = reader.int32() as any;
-          break;
+          continue;
         case 4:
+          if (tag !== 34) {
+            break;
+          }
+
           message.lastError = reader.string();
-          break;
+          continue;
         case 5:
+          if (tag !== 42) {
+            break;
+          }
+
           message.authUrl = reader.string();
-          break;
+          continue;
         case 6:
+          if (tag !== 50) {
+            break;
+          }
+
           message.ts = fromTimestamp(Timestamp.decode(reader, reader.uint32()));
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
 
   fromJSON(object: any): ConnectionStatusUpdate {
     return {
-      id: isSet(object.id) ? String(object.id) : '',
-      peerAddr: isSet(object.peerAddr) ? String(object.peerAddr) : undefined,
+      id: isSet(object.id) ? globalThis.String(object.id) : '',
+      peerAddr: isSet(object.peerAddr)
+        ? globalThis.String(object.peerAddr)
+        : undefined,
       status: isSet(object.status)
         ? connectionStatusUpdate_ConnectionStatusFromJSON(object.status)
         : 0,
-      lastError: isSet(object.lastError) ? String(object.lastError) : undefined,
-      authUrl: isSet(object.authUrl) ? String(object.authUrl) : undefined,
+      lastError: isSet(object.lastError)
+        ? globalThis.String(object.lastError)
+        : undefined,
+      authUrl: isSet(object.authUrl)
+        ? globalThis.String(object.authUrl)
+        : undefined,
       ts: isSet(object.ts) ? fromJsonTimestamp(object.ts) : undefined,
     };
   },
 
   toJSON(message: ConnectionStatusUpdate): unknown {
     const obj: any = {};
-    message.id !== undefined && (obj.id = message.id);
-    message.peerAddr !== undefined && (obj.peerAddr = message.peerAddr);
-    message.status !== undefined &&
-      (obj.status = connectionStatusUpdate_ConnectionStatusToJSON(
-        message.status
-      ));
-    message.lastError !== undefined && (obj.lastError = message.lastError);
-    message.authUrl !== undefined && (obj.authUrl = message.authUrl);
-    message.ts !== undefined && (obj.ts = message.ts.toISOString());
+    if (message.id !== '') {
+      obj.id = message.id;
+    }
+    if (message.peerAddr !== undefined) {
+      obj.peerAddr = message.peerAddr;
+    }
+    if (message.status !== 0) {
+      obj.status = connectionStatusUpdate_ConnectionStatusToJSON(
+        message.status,
+      );
+    }
+    if (message.lastError !== undefined) {
+      obj.lastError = message.lastError;
+    }
+    if (message.authUrl !== undefined) {
+      obj.authUrl = message.authUrl;
+    }
+    if (message.ts !== undefined) {
+      obj.ts = message.ts.toISOString();
+    }
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<ConnectionStatusUpdate>, I>>(
+    base?: I,
+  ): ConnectionStatusUpdate {
+    return ConnectionStatusUpdate.fromPartial(base ?? ({} as any));
+  },
   fromPartial<I extends Exact<DeepPartial<ConnectionStatusUpdate>, I>>(
-    object: I
+    object: I,
   ): ConnectionStatusUpdate {
     const message = createBaseConnectionStatusUpdate();
     message.id = object.id ?? '';
@@ -1466,7 +2195,7 @@ function createBaseKeyUsage(): KeyUsage {
 export const KeyUsage = {
   encode(
     message: KeyUsage,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.digitalSignature === true) {
       writer.uint32(8).bool(message.digitalSignature);
@@ -1505,49 +2234,95 @@ export const KeyUsage = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): KeyUsage {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseKeyUsage();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 8) {
+            break;
+          }
+
           message.digitalSignature = reader.bool();
-          break;
+          continue;
         case 2:
+          if (tag !== 16) {
+            break;
+          }
+
           message.contentCommitment = reader.bool();
-          break;
+          continue;
         case 3:
+          if (tag !== 24) {
+            break;
+          }
+
           message.keyEncipherment = reader.bool();
-          break;
+          continue;
         case 4:
+          if (tag !== 32) {
+            break;
+          }
+
           message.dataEncipherment = reader.bool();
-          break;
+          continue;
         case 5:
+          if (tag !== 40) {
+            break;
+          }
+
           message.keyAgreement = reader.bool();
-          break;
+          continue;
         case 6:
+          if (tag !== 48) {
+            break;
+          }
+
           message.certSign = reader.bool();
-          break;
+          continue;
         case 7:
+          if (tag !== 56) {
+            break;
+          }
+
           message.crlSign = reader.bool();
-          break;
+          continue;
         case 8:
+          if (tag !== 64) {
+            break;
+          }
+
           message.encipherOnly = reader.bool();
-          break;
+          continue;
         case 9:
+          if (tag !== 72) {
+            break;
+          }
+
           message.decipherOnly = reader.bool();
-          break;
+          continue;
         case 10:
+          if (tag !== 80) {
+            break;
+          }
+
           message.serverAuth = reader.bool();
-          break;
+          continue;
         case 11:
+          if (tag !== 88) {
+            break;
+          }
+
           message.clientAuth = reader.bool();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -1555,56 +2330,82 @@ export const KeyUsage = {
   fromJSON(object: any): KeyUsage {
     return {
       digitalSignature: isSet(object.digitalSignature)
-        ? Boolean(object.digitalSignature)
+        ? globalThis.Boolean(object.digitalSignature)
         : false,
       contentCommitment: isSet(object.contentCommitment)
-        ? Boolean(object.contentCommitment)
+        ? globalThis.Boolean(object.contentCommitment)
         : false,
       keyEncipherment: isSet(object.keyEncipherment)
-        ? Boolean(object.keyEncipherment)
+        ? globalThis.Boolean(object.keyEncipherment)
         : false,
       dataEncipherment: isSet(object.dataEncipherment)
-        ? Boolean(object.dataEncipherment)
+        ? globalThis.Boolean(object.dataEncipherment)
         : false,
       keyAgreement: isSet(object.keyAgreement)
-        ? Boolean(object.keyAgreement)
+        ? globalThis.Boolean(object.keyAgreement)
         : false,
-      certSign: isSet(object.certSign) ? Boolean(object.certSign) : false,
-      crlSign: isSet(object.crlSign) ? Boolean(object.crlSign) : false,
+      certSign: isSet(object.certSign)
+        ? globalThis.Boolean(object.certSign)
+        : false,
+      crlSign: isSet(object.crlSign)
+        ? globalThis.Boolean(object.crlSign)
+        : false,
       encipherOnly: isSet(object.encipherOnly)
-        ? Boolean(object.encipherOnly)
+        ? globalThis.Boolean(object.encipherOnly)
         : false,
       decipherOnly: isSet(object.decipherOnly)
-        ? Boolean(object.decipherOnly)
+        ? globalThis.Boolean(object.decipherOnly)
         : false,
-      serverAuth: isSet(object.serverAuth) ? Boolean(object.serverAuth) : false,
-      clientAuth: isSet(object.clientAuth) ? Boolean(object.clientAuth) : false,
+      serverAuth: isSet(object.serverAuth)
+        ? globalThis.Boolean(object.serverAuth)
+        : false,
+      clientAuth: isSet(object.clientAuth)
+        ? globalThis.Boolean(object.clientAuth)
+        : false,
     };
   },
 
   toJSON(message: KeyUsage): unknown {
     const obj: any = {};
-    message.digitalSignature !== undefined &&
-      (obj.digitalSignature = message.digitalSignature);
-    message.contentCommitment !== undefined &&
-      (obj.contentCommitment = message.contentCommitment);
-    message.keyEncipherment !== undefined &&
-      (obj.keyEncipherment = message.keyEncipherment);
-    message.dataEncipherment !== undefined &&
-      (obj.dataEncipherment = message.dataEncipherment);
-    message.keyAgreement !== undefined &&
-      (obj.keyAgreement = message.keyAgreement);
-    message.certSign !== undefined && (obj.certSign = message.certSign);
-    message.crlSign !== undefined && (obj.crlSign = message.crlSign);
-    message.encipherOnly !== undefined &&
-      (obj.encipherOnly = message.encipherOnly);
-    message.decipherOnly !== undefined &&
-      (obj.decipherOnly = message.decipherOnly);
-    message.serverAuth !== undefined && (obj.serverAuth = message.serverAuth);
-    message.clientAuth !== undefined && (obj.clientAuth = message.clientAuth);
+    if (message.digitalSignature === true) {
+      obj.digitalSignature = message.digitalSignature;
+    }
+    if (message.contentCommitment === true) {
+      obj.contentCommitment = message.contentCommitment;
+    }
+    if (message.keyEncipherment === true) {
+      obj.keyEncipherment = message.keyEncipherment;
+    }
+    if (message.dataEncipherment === true) {
+      obj.dataEncipherment = message.dataEncipherment;
+    }
+    if (message.keyAgreement === true) {
+      obj.keyAgreement = message.keyAgreement;
+    }
+    if (message.certSign === true) {
+      obj.certSign = message.certSign;
+    }
+    if (message.crlSign === true) {
+      obj.crlSign = message.crlSign;
+    }
+    if (message.encipherOnly === true) {
+      obj.encipherOnly = message.encipherOnly;
+    }
+    if (message.decipherOnly === true) {
+      obj.decipherOnly = message.decipherOnly;
+    }
+    if (message.serverAuth === true) {
+      obj.serverAuth = message.serverAuth;
+    }
+    if (message.clientAuth === true) {
+      obj.clientAuth = message.clientAuth;
+    }
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<KeyUsage>, I>>(base?: I): KeyUsage {
+    return KeyUsage.fromPartial(base ?? ({} as any));
+  },
   fromPartial<I extends Exact<DeepPartial<KeyUsage>, I>>(object: I): KeyUsage {
     const message = createBaseKeyUsage();
     message.digitalSignature = object.digitalSignature ?? false;
@@ -1669,120 +2470,152 @@ export const Name = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): Name {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseName();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.country.push(reader.string());
-          break;
+          continue;
         case 2:
+          if (tag !== 18) {
+            break;
+          }
+
           message.organization.push(reader.string());
-          break;
+          continue;
         case 3:
+          if (tag !== 26) {
+            break;
+          }
+
           message.organizationalUnit.push(reader.string());
-          break;
+          continue;
         case 4:
+          if (tag !== 34) {
+            break;
+          }
+
           message.locality.push(reader.string());
-          break;
+          continue;
         case 5:
+          if (tag !== 42) {
+            break;
+          }
+
           message.province.push(reader.string());
-          break;
+          continue;
         case 6:
+          if (tag !== 50) {
+            break;
+          }
+
           message.streetAddress.push(reader.string());
-          break;
+          continue;
         case 7:
+          if (tag !== 58) {
+            break;
+          }
+
           message.postalCode.push(reader.string());
-          break;
+          continue;
         case 8:
+          if (tag !== 66) {
+            break;
+          }
+
           message.serialNumber = reader.string();
-          break;
+          continue;
         case 9:
+          if (tag !== 74) {
+            break;
+          }
+
           message.commonName = reader.string();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
 
   fromJSON(object: any): Name {
     return {
-      country: Array.isArray(object?.country)
-        ? object.country.map((e: any) => String(e))
+      country: globalThis.Array.isArray(object?.country)
+        ? object.country.map((e: any) => globalThis.String(e))
         : [],
-      organization: Array.isArray(object?.organization)
-        ? object.organization.map((e: any) => String(e))
+      organization: globalThis.Array.isArray(object?.organization)
+        ? object.organization.map((e: any) => globalThis.String(e))
         : [],
-      organizationalUnit: Array.isArray(object?.organizationalUnit)
-        ? object.organizationalUnit.map((e: any) => String(e))
+      organizationalUnit: globalThis.Array.isArray(object?.organizationalUnit)
+        ? object.organizationalUnit.map((e: any) => globalThis.String(e))
         : [],
-      locality: Array.isArray(object?.locality)
-        ? object.locality.map((e: any) => String(e))
+      locality: globalThis.Array.isArray(object?.locality)
+        ? object.locality.map((e: any) => globalThis.String(e))
         : [],
-      province: Array.isArray(object?.province)
-        ? object.province.map((e: any) => String(e))
+      province: globalThis.Array.isArray(object?.province)
+        ? object.province.map((e: any) => globalThis.String(e))
         : [],
-      streetAddress: Array.isArray(object?.streetAddress)
-        ? object.streetAddress.map((e: any) => String(e))
+      streetAddress: globalThis.Array.isArray(object?.streetAddress)
+        ? object.streetAddress.map((e: any) => globalThis.String(e))
         : [],
-      postalCode: Array.isArray(object?.postalCode)
-        ? object.postalCode.map((e: any) => String(e))
+      postalCode: globalThis.Array.isArray(object?.postalCode)
+        ? object.postalCode.map((e: any) => globalThis.String(e))
         : [],
       serialNumber: isSet(object.serialNumber)
-        ? String(object.serialNumber)
+        ? globalThis.String(object.serialNumber)
         : '',
-      commonName: isSet(object.commonName) ? String(object.commonName) : '',
+      commonName: isSet(object.commonName)
+        ? globalThis.String(object.commonName)
+        : '',
     };
   },
 
   toJSON(message: Name): unknown {
     const obj: any = {};
-    if (message.country) {
-      obj.country = message.country.map((e) => e);
-    } else {
-      obj.country = [];
+    if (message.country?.length) {
+      obj.country = message.country;
     }
-    if (message.organization) {
-      obj.organization = message.organization.map((e) => e);
-    } else {
-      obj.organization = [];
+    if (message.organization?.length) {
+      obj.organization = message.organization;
     }
-    if (message.organizationalUnit) {
-      obj.organizationalUnit = message.organizationalUnit.map((e) => e);
-    } else {
-      obj.organizationalUnit = [];
+    if (message.organizationalUnit?.length) {
+      obj.organizationalUnit = message.organizationalUnit;
     }
-    if (message.locality) {
-      obj.locality = message.locality.map((e) => e);
-    } else {
-      obj.locality = [];
+    if (message.locality?.length) {
+      obj.locality = message.locality;
     }
-    if (message.province) {
-      obj.province = message.province.map((e) => e);
-    } else {
-      obj.province = [];
+    if (message.province?.length) {
+      obj.province = message.province;
     }
-    if (message.streetAddress) {
-      obj.streetAddress = message.streetAddress.map((e) => e);
-    } else {
-      obj.streetAddress = [];
+    if (message.streetAddress?.length) {
+      obj.streetAddress = message.streetAddress;
     }
-    if (message.postalCode) {
-      obj.postalCode = message.postalCode.map((e) => e);
-    } else {
-      obj.postalCode = [];
+    if (message.postalCode?.length) {
+      obj.postalCode = message.postalCode;
     }
-    message.serialNumber !== undefined &&
-      (obj.serialNumber = message.serialNumber);
-    message.commonName !== undefined && (obj.commonName = message.commonName);
+    if (message.serialNumber !== '') {
+      obj.serialNumber = message.serialNumber;
+    }
+    if (message.commonName !== '') {
+      obj.commonName = message.commonName;
+    }
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Name>, I>>(base?: I): Name {
+    return Name.fromPartial(base ?? ({} as any));
+  },
   fromPartial<I extends Exact<DeepPartial<Name>, I>>(object: I): Name {
     const message = createBaseName();
     message.country = object.country?.map((e) => e) || [];
@@ -1827,7 +2660,7 @@ function createBaseCertificateInfo(): CertificateInfo {
 export const CertificateInfo = {
   encode(
     message: CertificateInfo,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.version !== 0) {
       writer.uint32(8).int64(message.version);
@@ -1844,13 +2677,13 @@ export const CertificateInfo = {
     if (message.notBefore !== undefined) {
       Timestamp.encode(
         toTimestamp(message.notBefore),
-        writer.uint32(42).fork()
+        writer.uint32(42).fork(),
       ).ldelim();
     }
     if (message.notAfter !== undefined) {
       Timestamp.encode(
         toTimestamp(message.notAfter),
-        writer.uint32(50).fork()
+        writer.uint32(50).fork(),
       ).ldelim();
     }
     if (message.keyUsage !== undefined) {
@@ -1902,91 +2735,177 @@ export const CertificateInfo = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): CertificateInfo {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseCertificateInfo();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 8) {
+            break;
+          }
+
           message.version = longToNumber(reader.int64() as Long);
-          break;
+          continue;
         case 2:
+          if (tag !== 18) {
+            break;
+          }
+
           message.serial = reader.string();
-          break;
+          continue;
         case 3:
+          if (tag !== 26) {
+            break;
+          }
+
           message.issuer = Name.decode(reader, reader.uint32());
-          break;
+          continue;
         case 4:
+          if (tag !== 34) {
+            break;
+          }
+
           message.subject = Name.decode(reader, reader.uint32());
-          break;
+          continue;
         case 5:
+          if (tag !== 42) {
+            break;
+          }
+
           message.notBefore = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32())
+            Timestamp.decode(reader, reader.uint32()),
           );
-          break;
+          continue;
         case 6:
+          if (tag !== 50) {
+            break;
+          }
+
           message.notAfter = fromTimestamp(
-            Timestamp.decode(reader, reader.uint32())
+            Timestamp.decode(reader, reader.uint32()),
           );
-          break;
+          continue;
         case 7:
+          if (tag !== 58) {
+            break;
+          }
+
           message.keyUsage = KeyUsage.decode(reader, reader.uint32());
-          break;
+          continue;
         case 10:
+          if (tag !== 82) {
+            break;
+          }
+
           message.dnsNames.push(reader.string());
-          break;
+          continue;
         case 11:
+          if (tag !== 90) {
+            break;
+          }
+
           message.emailAddresses.push(reader.string());
-          break;
+          continue;
         case 12:
+          if (tag !== 98) {
+            break;
+          }
+
           message.ipAddresses.push(reader.string());
-          break;
+          continue;
         case 13:
+          if (tag !== 106) {
+            break;
+          }
+
           message.uris.push(reader.string());
-          break;
+          continue;
         case 14:
+          if (tag !== 112) {
+            break;
+          }
+
           message.permittedDnsDomainsCritical = reader.bool();
-          break;
+          continue;
         case 15:
+          if (tag !== 122) {
+            break;
+          }
+
           message.permittedDnsDomains.push(reader.string());
-          break;
+          continue;
         case 16:
+          if (tag !== 130) {
+            break;
+          }
+
           message.excludedDnsDomains.push(reader.string());
-          break;
+          continue;
         case 17:
+          if (tag !== 138) {
+            break;
+          }
+
           message.permittedIpRanges.push(reader.string());
-          break;
+          continue;
         case 18:
+          if (tag !== 146) {
+            break;
+          }
+
           message.excludedIpRanges.push(reader.string());
-          break;
+          continue;
         case 19:
+          if (tag !== 154) {
+            break;
+          }
+
           message.permittedEmailAddresses.push(reader.string());
-          break;
+          continue;
         case 20:
+          if (tag !== 162) {
+            break;
+          }
+
           message.excludedEmailAddresses.push(reader.string());
-          break;
+          continue;
         case 21:
+          if (tag !== 170) {
+            break;
+          }
+
           message.permittedUriDomains.push(reader.string());
-          break;
+          continue;
         case 22:
+          if (tag !== 178) {
+            break;
+          }
+
           message.excludedUriDomains.push(reader.string());
-          break;
+          continue;
         case 23:
+          if (tag !== 186) {
+            break;
+          }
+
           message.error = reader.string();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
 
   fromJSON(object: any): CertificateInfo {
     return {
-      version: isSet(object.version) ? Number(object.version) : 0,
-      serial: isSet(object.serial) ? String(object.serial) : '',
+      version: isSet(object.version) ? globalThis.Number(object.version) : 0,
+      serial: isSet(object.serial) ? globalThis.String(object.serial) : '',
       issuer: isSet(object.issuer) ? Name.fromJSON(object.issuer) : undefined,
       subject: isSet(object.subject)
         ? Name.fromJSON(object.subject)
@@ -2000,138 +2919,128 @@ export const CertificateInfo = {
       keyUsage: isSet(object.keyUsage)
         ? KeyUsage.fromJSON(object.keyUsage)
         : undefined,
-      dnsNames: Array.isArray(object?.dnsNames)
-        ? object.dnsNames.map((e: any) => String(e))
+      dnsNames: globalThis.Array.isArray(object?.dnsNames)
+        ? object.dnsNames.map((e: any) => globalThis.String(e))
         : [],
-      emailAddresses: Array.isArray(object?.emailAddresses)
-        ? object.emailAddresses.map((e: any) => String(e))
+      emailAddresses: globalThis.Array.isArray(object?.emailAddresses)
+        ? object.emailAddresses.map((e: any) => globalThis.String(e))
         : [],
-      ipAddresses: Array.isArray(object?.ipAddresses)
-        ? object.ipAddresses.map((e: any) => String(e))
+      ipAddresses: globalThis.Array.isArray(object?.ipAddresses)
+        ? object.ipAddresses.map((e: any) => globalThis.String(e))
         : [],
-      uris: Array.isArray(object?.uris)
-        ? object.uris.map((e: any) => String(e))
+      uris: globalThis.Array.isArray(object?.uris)
+        ? object.uris.map((e: any) => globalThis.String(e))
         : [],
       permittedDnsDomainsCritical: isSet(object.permittedDnsDomainsCritical)
-        ? Boolean(object.permittedDnsDomainsCritical)
+        ? globalThis.Boolean(object.permittedDnsDomainsCritical)
         : false,
-      permittedDnsDomains: Array.isArray(object?.permittedDnsDomains)
-        ? object.permittedDnsDomains.map((e: any) => String(e))
+      permittedDnsDomains: globalThis.Array.isArray(object?.permittedDnsDomains)
+        ? object.permittedDnsDomains.map((e: any) => globalThis.String(e))
         : [],
-      excludedDnsDomains: Array.isArray(object?.excludedDnsDomains)
-        ? object.excludedDnsDomains.map((e: any) => String(e))
+      excludedDnsDomains: globalThis.Array.isArray(object?.excludedDnsDomains)
+        ? object.excludedDnsDomains.map((e: any) => globalThis.String(e))
         : [],
-      permittedIpRanges: Array.isArray(object?.permittedIpRanges)
-        ? object.permittedIpRanges.map((e: any) => String(e))
+      permittedIpRanges: globalThis.Array.isArray(object?.permittedIpRanges)
+        ? object.permittedIpRanges.map((e: any) => globalThis.String(e))
         : [],
-      excludedIpRanges: Array.isArray(object?.excludedIpRanges)
-        ? object.excludedIpRanges.map((e: any) => String(e))
+      excludedIpRanges: globalThis.Array.isArray(object?.excludedIpRanges)
+        ? object.excludedIpRanges.map((e: any) => globalThis.String(e))
         : [],
-      permittedEmailAddresses: Array.isArray(object?.permittedEmailAddresses)
-        ? object.permittedEmailAddresses.map((e: any) => String(e))
+      permittedEmailAddresses: globalThis.Array.isArray(
+        object?.permittedEmailAddresses,
+      )
+        ? object.permittedEmailAddresses.map((e: any) => globalThis.String(e))
         : [],
-      excludedEmailAddresses: Array.isArray(object?.excludedEmailAddresses)
-        ? object.excludedEmailAddresses.map((e: any) => String(e))
+      excludedEmailAddresses: globalThis.Array.isArray(
+        object?.excludedEmailAddresses,
+      )
+        ? object.excludedEmailAddresses.map((e: any) => globalThis.String(e))
         : [],
-      permittedUriDomains: Array.isArray(object?.permittedUriDomains)
-        ? object.permittedUriDomains.map((e: any) => String(e))
+      permittedUriDomains: globalThis.Array.isArray(object?.permittedUriDomains)
+        ? object.permittedUriDomains.map((e: any) => globalThis.String(e))
         : [],
-      excludedUriDomains: Array.isArray(object?.excludedUriDomains)
-        ? object.excludedUriDomains.map((e: any) => String(e))
+      excludedUriDomains: globalThis.Array.isArray(object?.excludedUriDomains)
+        ? object.excludedUriDomains.map((e: any) => globalThis.String(e))
         : [],
-      error: isSet(object.error) ? String(object.error) : undefined,
+      error: isSet(object.error) ? globalThis.String(object.error) : undefined,
     };
   },
 
   toJSON(message: CertificateInfo): unknown {
     const obj: any = {};
-    message.version !== undefined &&
-      (obj.version = Math.round(message.version));
-    message.serial !== undefined && (obj.serial = message.serial);
-    message.issuer !== undefined &&
-      (obj.issuer = message.issuer ? Name.toJSON(message.issuer) : undefined);
-    message.subject !== undefined &&
-      (obj.subject = message.subject
-        ? Name.toJSON(message.subject)
-        : undefined);
-    message.notBefore !== undefined &&
-      (obj.notBefore = message.notBefore.toISOString());
-    message.notAfter !== undefined &&
-      (obj.notAfter = message.notAfter.toISOString());
-    message.keyUsage !== undefined &&
-      (obj.keyUsage = message.keyUsage
-        ? KeyUsage.toJSON(message.keyUsage)
-        : undefined);
-    if (message.dnsNames) {
-      obj.dnsNames = message.dnsNames.map((e) => e);
-    } else {
-      obj.dnsNames = [];
+    if (message.version !== 0) {
+      obj.version = Math.round(message.version);
     }
-    if (message.emailAddresses) {
-      obj.emailAddresses = message.emailAddresses.map((e) => e);
-    } else {
-      obj.emailAddresses = [];
+    if (message.serial !== '') {
+      obj.serial = message.serial;
     }
-    if (message.ipAddresses) {
-      obj.ipAddresses = message.ipAddresses.map((e) => e);
-    } else {
-      obj.ipAddresses = [];
+    if (message.issuer !== undefined) {
+      obj.issuer = Name.toJSON(message.issuer);
     }
-    if (message.uris) {
-      obj.uris = message.uris.map((e) => e);
-    } else {
-      obj.uris = [];
+    if (message.subject !== undefined) {
+      obj.subject = Name.toJSON(message.subject);
     }
-    message.permittedDnsDomainsCritical !== undefined &&
-      (obj.permittedDnsDomainsCritical = message.permittedDnsDomainsCritical);
-    if (message.permittedDnsDomains) {
-      obj.permittedDnsDomains = message.permittedDnsDomains.map((e) => e);
-    } else {
-      obj.permittedDnsDomains = [];
+    if (message.notBefore !== undefined) {
+      obj.notBefore = message.notBefore.toISOString();
     }
-    if (message.excludedDnsDomains) {
-      obj.excludedDnsDomains = message.excludedDnsDomains.map((e) => e);
-    } else {
-      obj.excludedDnsDomains = [];
+    if (message.notAfter !== undefined) {
+      obj.notAfter = message.notAfter.toISOString();
     }
-    if (message.permittedIpRanges) {
-      obj.permittedIpRanges = message.permittedIpRanges.map((e) => e);
-    } else {
-      obj.permittedIpRanges = [];
+    if (message.keyUsage !== undefined) {
+      obj.keyUsage = KeyUsage.toJSON(message.keyUsage);
     }
-    if (message.excludedIpRanges) {
-      obj.excludedIpRanges = message.excludedIpRanges.map((e) => e);
-    } else {
-      obj.excludedIpRanges = [];
+    if (message.dnsNames?.length) {
+      obj.dnsNames = message.dnsNames;
     }
-    if (message.permittedEmailAddresses) {
-      obj.permittedEmailAddresses = message.permittedEmailAddresses.map(
-        (e) => e
-      );
-    } else {
-      obj.permittedEmailAddresses = [];
+    if (message.emailAddresses?.length) {
+      obj.emailAddresses = message.emailAddresses;
     }
-    if (message.excludedEmailAddresses) {
-      obj.excludedEmailAddresses = message.excludedEmailAddresses.map((e) => e);
-    } else {
-      obj.excludedEmailAddresses = [];
+    if (message.ipAddresses?.length) {
+      obj.ipAddresses = message.ipAddresses;
     }
-    if (message.permittedUriDomains) {
-      obj.permittedUriDomains = message.permittedUriDomains.map((e) => e);
-    } else {
-      obj.permittedUriDomains = [];
+    if (message.uris?.length) {
+      obj.uris = message.uris;
     }
-    if (message.excludedUriDomains) {
-      obj.excludedUriDomains = message.excludedUriDomains.map((e) => e);
-    } else {
-      obj.excludedUriDomains = [];
+    if (message.permittedDnsDomainsCritical === true) {
+      obj.permittedDnsDomainsCritical = message.permittedDnsDomainsCritical;
     }
-    message.error !== undefined && (obj.error = message.error);
+    if (message.permittedDnsDomains?.length) {
+      obj.permittedDnsDomains = message.permittedDnsDomains;
+    }
+    if (message.excludedDnsDomains?.length) {
+      obj.excludedDnsDomains = message.excludedDnsDomains;
+    }
+    if (message.permittedIpRanges?.length) {
+      obj.permittedIpRanges = message.permittedIpRanges;
+    }
+    if (message.excludedIpRanges?.length) {
+      obj.excludedIpRanges = message.excludedIpRanges;
+    }
+    if (message.permittedEmailAddresses?.length) {
+      obj.permittedEmailAddresses = message.permittedEmailAddresses;
+    }
+    if (message.excludedEmailAddresses?.length) {
+      obj.excludedEmailAddresses = message.excludedEmailAddresses;
+    }
+    if (message.permittedUriDomains?.length) {
+      obj.permittedUriDomains = message.permittedUriDomains;
+    }
+    if (message.excludedUriDomains?.length) {
+      obj.excludedUriDomains = message.excludedUriDomains;
+    }
+    if (message.error !== undefined) {
+      obj.error = message.error;
+    }
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<CertificateInfo>, I>>(
+    base?: I,
+  ): CertificateInfo {
+    return CertificateInfo.fromPartial(base ?? ({} as any));
+  },
   fromPartial<I extends Exact<DeepPartial<CertificateInfo>, I>>(
-    object: I
+    object: I,
   ): CertificateInfo {
     const message = createBaseCertificateInfo();
     message.version = object.version ?? 0;
@@ -2174,13 +3083,13 @@ export const CertificateInfo = {
 };
 
 function createBaseCertificate(): Certificate {
-  return { cert: new Uint8Array(), key: undefined, info: undefined };
+  return { cert: new Uint8Array(0), key: undefined, info: undefined };
 }
 
 export const Certificate = {
   encode(
     message: Certificate,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.cert.length !== 0) {
       writer.uint32(10).bytes(message.cert);
@@ -2195,25 +3104,39 @@ export const Certificate = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): Certificate {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseCertificate();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.cert = reader.bytes();
-          break;
+          continue;
         case 2:
+          if (tag !== 18) {
+            break;
+          }
+
           message.key = reader.bytes();
-          break;
+          continue;
         case 3:
+          if (tag !== 26) {
+            break;
+          }
+
           message.info = CertificateInfo.decode(reader, reader.uint32());
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -2222,7 +3145,7 @@ export const Certificate = {
     return {
       cert: isSet(object.cert)
         ? bytesFromBase64(object.cert)
-        : new Uint8Array(),
+        : new Uint8Array(0),
       key: isSet(object.key) ? bytesFromBase64(object.key) : undefined,
       info: isSet(object.info)
         ? CertificateInfo.fromJSON(object.info)
@@ -2232,25 +3155,26 @@ export const Certificate = {
 
   toJSON(message: Certificate): unknown {
     const obj: any = {};
-    message.cert !== undefined &&
-      (obj.cert = base64FromBytes(
-        message.cert !== undefined ? message.cert : new Uint8Array()
-      ));
-    message.key !== undefined &&
-      (obj.key =
-        message.key !== undefined ? base64FromBytes(message.key) : undefined);
-    message.info !== undefined &&
-      (obj.info = message.info
-        ? CertificateInfo.toJSON(message.info)
-        : undefined);
+    if (message.cert.length !== 0) {
+      obj.cert = base64FromBytes(message.cert);
+    }
+    if (message.key !== undefined) {
+      obj.key = base64FromBytes(message.key);
+    }
+    if (message.info !== undefined) {
+      obj.info = CertificateInfo.toJSON(message.info);
+    }
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Certificate>, I>>(base?: I): Certificate {
+    return Certificate.fromPartial(base ?? ({} as any));
+  },
   fromPartial<I extends Exact<DeepPartial<Certificate>, I>>(
-    object: I
+    object: I,
   ): Certificate {
     const message = createBaseCertificate();
-    message.cert = object.cert ?? new Uint8Array();
+    message.cert = object.cert ?? new Uint8Array(0);
     message.key = object.key ?? undefined;
     message.info =
       object.info !== undefined && object.info !== null
@@ -2267,7 +3191,7 @@ function createBaseClientCertFromStore(): ClientCertFromStore {
 export const ClientCertFromStore = {
   encode(
     message: ClientCertFromStore,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.issuerFilter !== undefined) {
       writer.uint32(10).string(message.issuerFilter);
@@ -2279,22 +3203,32 @@ export const ClientCertFromStore = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): ClientCertFromStore {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseClientCertFromStore();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.issuerFilter = reader.string();
-          break;
+          continue;
         case 2:
+          if (tag !== 18) {
+            break;
+          }
+
           message.subjectFilter = reader.string();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
@@ -2302,25 +3236,32 @@ export const ClientCertFromStore = {
   fromJSON(object: any): ClientCertFromStore {
     return {
       issuerFilter: isSet(object.issuerFilter)
-        ? String(object.issuerFilter)
+        ? globalThis.String(object.issuerFilter)
         : undefined,
       subjectFilter: isSet(object.subjectFilter)
-        ? String(object.subjectFilter)
+        ? globalThis.String(object.subjectFilter)
         : undefined,
     };
   },
 
   toJSON(message: ClientCertFromStore): unknown {
     const obj: any = {};
-    message.issuerFilter !== undefined &&
-      (obj.issuerFilter = message.issuerFilter);
-    message.subjectFilter !== undefined &&
-      (obj.subjectFilter = message.subjectFilter);
+    if (message.issuerFilter !== undefined) {
+      obj.issuerFilter = message.issuerFilter;
+    }
+    if (message.subjectFilter !== undefined) {
+      obj.subjectFilter = message.subjectFilter;
+    }
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<ClientCertFromStore>, I>>(
+    base?: I,
+  ): ClientCertFromStore {
+    return ClientCertFromStore.fromPartial(base ?? ({} as any));
+  },
   fromPartial<I extends Exact<DeepPartial<ClientCertFromStore>, I>>(
-    object: I
+    object: I,
   ): ClientCertFromStore {
     const message = createBaseClientCertFromStore();
     message.issuerFilter = object.issuerFilter ?? undefined;
@@ -2332,6 +3273,7 @@ export const ClientCertFromStore = {
 function createBaseConnection(): Connection {
   return {
     name: undefined,
+    protocol: undefined,
     remoteAddr: '',
     listenAddr: undefined,
     pomeriumUrl: undefined,
@@ -2345,10 +3287,13 @@ function createBaseConnection(): Connection {
 export const Connection = {
   encode(
     message: Connection,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.name !== undefined) {
       writer.uint32(10).string(message.name);
+    }
+    if (message.protocol !== undefined) {
+      writer.uint32(80).int32(message.protocol);
     }
     if (message.remoteAddr !== '') {
       writer.uint32(18).string(message.remoteAddr);
@@ -2371,66 +3316,112 @@ export const Connection = {
     if (message.clientCertFromStore !== undefined) {
       ClientCertFromStore.encode(
         message.clientCertFromStore,
-        writer.uint32(74).fork()
+        writer.uint32(74).fork(),
       ).ldelim();
     }
     return writer;
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): Connection {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseConnection();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 10) {
+            break;
+          }
+
           message.name = reader.string();
-          break;
+          continue;
+        case 10:
+          if (tag !== 80) {
+            break;
+          }
+
+          message.protocol = reader.int32() as any;
+          continue;
         case 2:
+          if (tag !== 18) {
+            break;
+          }
+
           message.remoteAddr = reader.string();
-          break;
+          continue;
         case 3:
+          if (tag !== 26) {
+            break;
+          }
+
           message.listenAddr = reader.string();
-          break;
+          continue;
         case 4:
+          if (tag !== 34) {
+            break;
+          }
+
           message.pomeriumUrl = reader.string();
-          break;
+          continue;
         case 5:
+          if (tag !== 40) {
+            break;
+          }
+
           message.disableTlsVerification = reader.bool();
-          break;
+          continue;
         case 6:
+          if (tag !== 50) {
+            break;
+          }
+
           message.caCert = reader.bytes();
-          break;
+          continue;
         case 7:
+          if (tag !== 58) {
+            break;
+          }
+
           message.clientCert = Certificate.decode(reader, reader.uint32());
-          break;
+          continue;
         case 9:
+          if (tag !== 74) {
+            break;
+          }
+
           message.clientCertFromStore = ClientCertFromStore.decode(
             reader,
-            reader.uint32()
+            reader.uint32(),
           );
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
 
   fromJSON(object: any): Connection {
     return {
-      name: isSet(object.name) ? String(object.name) : undefined,
-      remoteAddr: isSet(object.remoteAddr) ? String(object.remoteAddr) : '',
+      name: isSet(object.name) ? globalThis.String(object.name) : undefined,
+      protocol: isSet(object.protocol)
+        ? protocolFromJSON(object.protocol)
+        : undefined,
+      remoteAddr: isSet(object.remoteAddr)
+        ? globalThis.String(object.remoteAddr)
+        : '',
       listenAddr: isSet(object.listenAddr)
-        ? String(object.listenAddr)
+        ? globalThis.String(object.listenAddr)
         : undefined,
       pomeriumUrl: isSet(object.pomeriumUrl)
-        ? String(object.pomeriumUrl)
+        ? globalThis.String(object.pomeriumUrl)
         : undefined,
       disableTlsVerification: isSet(object.disableTlsVerification)
-        ? Boolean(object.disableTlsVerification)
+        ? globalThis.Boolean(object.disableTlsVerification)
         : undefined,
       caCert: isSet(object.caCert) ? bytesFromBase64(object.caCert) : undefined,
       clientCert: isSet(object.clientCert)
@@ -2444,34 +3435,47 @@ export const Connection = {
 
   toJSON(message: Connection): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.remoteAddr !== undefined && (obj.remoteAddr = message.remoteAddr);
-    message.listenAddr !== undefined && (obj.listenAddr = message.listenAddr);
-    message.pomeriumUrl !== undefined &&
-      (obj.pomeriumUrl = message.pomeriumUrl);
-    message.disableTlsVerification !== undefined &&
-      (obj.disableTlsVerification = message.disableTlsVerification);
-    message.caCert !== undefined &&
-      (obj.caCert =
-        message.caCert !== undefined
-          ? base64FromBytes(message.caCert)
-          : undefined);
-    message.clientCert !== undefined &&
-      (obj.clientCert = message.clientCert
-        ? Certificate.toJSON(message.clientCert)
-        : undefined);
-    message.clientCertFromStore !== undefined &&
-      (obj.clientCertFromStore = message.clientCertFromStore
-        ? ClientCertFromStore.toJSON(message.clientCertFromStore)
-        : undefined);
+    if (message.name !== undefined) {
+      obj.name = message.name;
+    }
+    if (message.protocol !== undefined) {
+      obj.protocol = protocolToJSON(message.protocol);
+    }
+    if (message.remoteAddr !== '') {
+      obj.remoteAddr = message.remoteAddr;
+    }
+    if (message.listenAddr !== undefined) {
+      obj.listenAddr = message.listenAddr;
+    }
+    if (message.pomeriumUrl !== undefined) {
+      obj.pomeriumUrl = message.pomeriumUrl;
+    }
+    if (message.disableTlsVerification !== undefined) {
+      obj.disableTlsVerification = message.disableTlsVerification;
+    }
+    if (message.caCert !== undefined) {
+      obj.caCert = base64FromBytes(message.caCert);
+    }
+    if (message.clientCert !== undefined) {
+      obj.clientCert = Certificate.toJSON(message.clientCert);
+    }
+    if (message.clientCertFromStore !== undefined) {
+      obj.clientCertFromStore = ClientCertFromStore.toJSON(
+        message.clientCertFromStore,
+      );
+    }
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Connection>, I>>(base?: I): Connection {
+    return Connection.fromPartial(base ?? ({} as any));
+  },
   fromPartial<I extends Exact<DeepPartial<Connection>, I>>(
-    object: I
+    object: I,
   ): Connection {
     const message = createBaseConnection();
     message.name = object.name ?? undefined;
+    message.protocol = object.protocol ?? undefined;
     message.remoteAddr = object.remoteAddr ?? '';
     message.listenAddr = object.listenAddr ?? undefined;
     message.pomeriumUrl = object.pomeriumUrl ?? undefined;
@@ -2568,6 +3572,18 @@ export const ConfigService = {
       Buffer.from(ImportResponse.encode(value).finish()),
     responseDeserialize: (value: Buffer) => ImportResponse.decode(value),
   },
+  /** FetchRoutes fetches all the routes from the routes portal. */
+  fetchRoutes: {
+    path: '/pomerium.cli.Config/FetchRoutes',
+    requestStream: false,
+    responseStream: false,
+    requestSerialize: (value: FetchRoutesRequest) =>
+      Buffer.from(FetchRoutesRequest.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => FetchRoutesRequest.decode(value),
+    responseSerialize: (value: FetchRoutesResponse) =>
+      Buffer.from(FetchRoutesResponse.encode(value).finish()),
+    responseDeserialize: (value: Buffer) => FetchRoutesResponse.decode(value),
+  },
 } as const;
 
 export interface ConfigServer extends UntypedServiceImplementation {
@@ -2586,40 +3602,42 @@ export interface ConfigServer extends UntypedServiceImplementation {
   export: handleUnaryCall<ExportRequest, ConfigData>;
   /** Import imports previously serialized records */
   import: handleUnaryCall<ImportRequest, ImportResponse>;
+  /** FetchRoutes fetches all the routes from the routes portal. */
+  fetchRoutes: handleUnaryCall<FetchRoutesRequest, FetchRoutesResponse>;
 }
 
 export interface ConfigClient extends Client {
   /** List returns records that match Selector */
   list(
     request: Selector,
-    callback: (error: ServiceError | null, response: Records) => void
+    callback: (error: ServiceError | null, response: Records) => void,
   ): ClientUnaryCall;
   list(
     request: Selector,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: Records) => void
+    callback: (error: ServiceError | null, response: Records) => void,
   ): ClientUnaryCall;
   list(
     request: Selector,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: Records) => void
+    callback: (error: ServiceError | null, response: Records) => void,
   ): ClientUnaryCall;
   /** Delete deletes records that match Selector */
   delete(
     request: Selector,
     callback: (
       error: ServiceError | null,
-      response: DeleteRecordsResponse
-    ) => void
+      response: DeleteRecordsResponse,
+    ) => void,
   ): ClientUnaryCall;
   delete(
     request: Selector,
     metadata: Metadata,
     callback: (
       error: ServiceError | null,
-      response: DeleteRecordsResponse
-    ) => void
+      response: DeleteRecordsResponse,
+    ) => void,
   ): ClientUnaryCall;
   delete(
     request: Selector,
@@ -2627,8 +3645,8 @@ export interface ConfigClient extends Client {
     options: Partial<CallOptions>,
     callback: (
       error: ServiceError | null,
-      response: DeleteRecordsResponse
-    ) => void
+      response: DeleteRecordsResponse,
+    ) => void,
   ): ClientUnaryCall;
   /**
    * Upsert inserts (if no ID is provided) or updates records
@@ -2636,79 +3654,105 @@ export interface ConfigClient extends Client {
    */
   upsert(
     request: Record,
-    callback: (error: ServiceError | null, response: Record) => void
+    callback: (error: ServiceError | null, response: Record) => void,
   ): ClientUnaryCall;
   upsert(
     request: Record,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: Record) => void
+    callback: (error: ServiceError | null, response: Record) => void,
   ): ClientUnaryCall;
   upsert(
     request: Record,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: Record) => void
+    callback: (error: ServiceError | null, response: Record) => void,
   ): ClientUnaryCall;
   /** GetTags returns all tags. Note that tags are case sensitive */
   getTags(
     request: GetTagsRequest,
-    callback: (error: ServiceError | null, response: GetTagsResponse) => void
+    callback: (error: ServiceError | null, response: GetTagsResponse) => void,
   ): ClientUnaryCall;
   getTags(
     request: GetTagsRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: GetTagsResponse) => void
+    callback: (error: ServiceError | null, response: GetTagsResponse) => void,
   ): ClientUnaryCall;
   getTags(
     request: GetTagsRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: GetTagsResponse) => void
+    callback: (error: ServiceError | null, response: GetTagsResponse) => void,
   ): ClientUnaryCall;
   /** Export dumps config into serialized format */
   export(
     request: ExportRequest,
-    callback: (error: ServiceError | null, response: ConfigData) => void
+    callback: (error: ServiceError | null, response: ConfigData) => void,
   ): ClientUnaryCall;
   export(
     request: ExportRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: ConfigData) => void
+    callback: (error: ServiceError | null, response: ConfigData) => void,
   ): ClientUnaryCall;
   export(
     request: ExportRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: ConfigData) => void
+    callback: (error: ServiceError | null, response: ConfigData) => void,
   ): ClientUnaryCall;
   /** Import imports previously serialized records */
   import(
     request: ImportRequest,
-    callback: (error: ServiceError | null, response: ImportResponse) => void
+    callback: (error: ServiceError | null, response: ImportResponse) => void,
   ): ClientUnaryCall;
   import(
     request: ImportRequest,
     metadata: Metadata,
-    callback: (error: ServiceError | null, response: ImportResponse) => void
+    callback: (error: ServiceError | null, response: ImportResponse) => void,
   ): ClientUnaryCall;
   import(
     request: ImportRequest,
     metadata: Metadata,
     options: Partial<CallOptions>,
-    callback: (error: ServiceError | null, response: ImportResponse) => void
+    callback: (error: ServiceError | null, response: ImportResponse) => void,
+  ): ClientUnaryCall;
+  /** FetchRoutes fetches all the routes from the routes portal. */
+  fetchRoutes(
+    request: FetchRoutesRequest,
+    callback: (
+      error: ServiceError | null,
+      response: FetchRoutesResponse,
+    ) => void,
+  ): ClientUnaryCall;
+  fetchRoutes(
+    request: FetchRoutesRequest,
+    metadata: Metadata,
+    callback: (
+      error: ServiceError | null,
+      response: FetchRoutesResponse,
+    ) => void,
+  ): ClientUnaryCall;
+  fetchRoutes(
+    request: FetchRoutesRequest,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (
+      error: ServiceError | null,
+      response: FetchRoutesResponse,
+    ) => void,
   ): ClientUnaryCall;
 }
 
 export const ConfigClient = makeGenericClientConstructor(
   ConfigService,
-  'pomerium.cli.Config'
+  'pomerium.cli.Config',
 ) as unknown as {
   new (
     address: string,
     credentials: ChannelCredentials,
-    options?: Partial<ChannelOptions>
+    options?: Partial<ClientOptions>,
   ): ConfigClient;
   service: typeof ConfigService;
+  serviceName: string;
 };
 
 /** Listener service controls listeners */
@@ -2781,16 +3825,16 @@ export interface ListenerClient extends Client {
     request: ListenerUpdateRequest,
     callback: (
       error: ServiceError | null,
-      response: ListenerStatusResponse
-    ) => void
+      response: ListenerStatusResponse,
+    ) => void,
   ): ClientUnaryCall;
   update(
     request: ListenerUpdateRequest,
     metadata: Metadata,
     callback: (
       error: ServiceError | null,
-      response: ListenerStatusResponse
-    ) => void
+      response: ListenerStatusResponse,
+    ) => void,
   ): ClientUnaryCall;
   update(
     request: ListenerUpdateRequest,
@@ -2798,24 +3842,24 @@ export interface ListenerClient extends Client {
     options: Partial<CallOptions>,
     callback: (
       error: ServiceError | null,
-      response: ListenerStatusResponse
-    ) => void
+      response: ListenerStatusResponse,
+    ) => void,
   ): ClientUnaryCall;
   /** GetStatus returns current listener status for active tunnels */
   getStatus(
     request: Selector,
     callback: (
       error: ServiceError | null,
-      response: ListenerStatusResponse
-    ) => void
+      response: ListenerStatusResponse,
+    ) => void,
   ): ClientUnaryCall;
   getStatus(
     request: Selector,
     metadata: Metadata,
     callback: (
       error: ServiceError | null,
-      response: ListenerStatusResponse
-    ) => void
+      response: ListenerStatusResponse,
+    ) => void,
   ): ClientUnaryCall;
   getStatus(
     request: Selector,
@@ -2823,8 +3867,8 @@ export interface ListenerClient extends Client {
     options: Partial<CallOptions>,
     callback: (
       error: ServiceError | null,
-      response: ListenerStatusResponse
-    ) => void
+      response: ListenerStatusResponse,
+    ) => void,
   ): ClientUnaryCall;
   /**
    * StatusUpdates opens a stream to listen to connection status updates
@@ -2833,59 +3877,51 @@ export interface ListenerClient extends Client {
    */
   statusUpdates(
     request: StatusUpdatesRequest,
-    options?: Partial<CallOptions>
+    options?: Partial<CallOptions>,
   ): ClientReadableStream<ConnectionStatusUpdate>;
   statusUpdates(
     request: StatusUpdatesRequest,
     metadata?: Metadata,
-    options?: Partial<CallOptions>
+    options?: Partial<CallOptions>,
   ): ClientReadableStream<ConnectionStatusUpdate>;
 }
 
 export const ListenerClient = makeGenericClientConstructor(
   ListenerService,
-  'pomerium.cli.Listener'
+  'pomerium.cli.Listener',
 ) as unknown as {
   new (
     address: string,
     credentials: ChannelCredentials,
-    options?: Partial<ChannelOptions>
+    options?: Partial<ClientOptions>,
   ): ListenerClient;
   service: typeof ListenerService;
+  serviceName: string;
 };
 
-declare var self: any | undefined;
-declare var window: any | undefined;
-declare var global: any | undefined;
-var globalThis: any = (() => {
-  if (typeof globalThis !== 'undefined') return globalThis;
-  if (typeof self !== 'undefined') return self;
-  if (typeof window !== 'undefined') return window;
-  if (typeof global !== 'undefined') return global;
-  throw 'Unable to locate global object';
-})();
-
-const atob: (b64: string) => string =
-  globalThis.atob ||
-  ((b64) => globalThis.Buffer.from(b64, 'base64').toString('binary'));
 function bytesFromBase64(b64: string): Uint8Array {
-  const bin = atob(b64);
-  const arr = new Uint8Array(bin.length);
-  for (let i = 0; i < bin.length; ++i) {
-    arr[i] = bin.charCodeAt(i);
+  if (globalThis.Buffer) {
+    return Uint8Array.from(globalThis.Buffer.from(b64, 'base64'));
+  } else {
+    const bin = globalThis.atob(b64);
+    const arr = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; ++i) {
+      arr[i] = bin.charCodeAt(i);
+    }
+    return arr;
   }
-  return arr;
 }
 
-const btoa: (bin: string) => string =
-  globalThis.btoa ||
-  ((bin) => globalThis.Buffer.from(bin, 'binary').toString('base64'));
 function base64FromBytes(arr: Uint8Array): string {
-  const bin: string[] = [];
-  arr.forEach((byte) => {
-    bin.push(String.fromCharCode(byte));
-  });
-  return btoa(bin.join(''));
+  if (globalThis.Buffer) {
+    return globalThis.Buffer.from(arr).toString('base64');
+  } else {
+    const bin: string[] = [];
+    arr.forEach((byte) => {
+      bin.push(globalThis.String.fromCharCode(byte));
+    });
+    return globalThis.btoa(bin.join(''));
+  }
 }
 
 type Builtin =
@@ -2899,46 +3935,45 @@ type Builtin =
 
 export type DeepPartial<T> = T extends Builtin
   ? T
-  : T extends Array<infer U>
-  ? Array<DeepPartial<U>>
-  : T extends ReadonlyArray<infer U>
-  ? ReadonlyArray<DeepPartial<U>>
-  : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
-  : Partial<T>;
+  : T extends globalThis.Array<infer U>
+    ? globalThis.Array<DeepPartial<U>>
+    : T extends ReadonlyArray<infer U>
+      ? ReadonlyArray<DeepPartial<U>>
+      : T extends {}
+        ? { [K in keyof T]?: DeepPartial<T[K]> }
+        : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
-  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
-        never
-      >;
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & {
+      [K in Exclude<keyof I, KeysOfUnion<P>>]: never;
+    };
 
 function toTimestamp(date: Date): Timestamp {
-  const seconds = date.getTime() / 1_000;
+  const seconds = Math.trunc(date.getTime() / 1_000);
   const nanos = (date.getTime() % 1_000) * 1_000_000;
   return { seconds, nanos };
 }
 
 function fromTimestamp(t: Timestamp): Date {
-  let millis = t.seconds * 1_000;
-  millis += t.nanos / 1_000_000;
-  return new Date(millis);
+  let millis = (t.seconds || 0) * 1_000;
+  millis += (t.nanos || 0) / 1_000_000;
+  return new globalThis.Date(millis);
 }
 
 function fromJsonTimestamp(o: any): Date {
-  if (o instanceof Date) {
+  if (o instanceof globalThis.Date) {
     return o;
   } else if (typeof o === 'string') {
-    return new Date(o);
+    return new globalThis.Date(o);
   } else {
     return fromTimestamp(Timestamp.fromJSON(o));
   }
 }
 
 function longToNumber(long: Long): number {
-  if (long.gt(Number.MAX_SAFE_INTEGER)) {
+  if (long.gt(globalThis.Number.MAX_SAFE_INTEGER)) {
     throw new globalThis.Error('Value is larger than Number.MAX_SAFE_INTEGER');
   }
   return long.toNumber();

--- a/src/shared/pb/google/api/http.ts
+++ b/src/shared/pb/google/api/http.ts
@@ -407,7 +407,7 @@ export const Http = {
       object.fullyDecodeReservedExpansion !== null
     ) {
       message.fullyDecodeReservedExpansion = Boolean(
-        object.fullyDecodeReservedExpansion
+        object.fullyDecodeReservedExpansion,
       );
     } else {
       message.fullyDecodeReservedExpansion = false;
@@ -419,7 +419,7 @@ export const Http = {
     const obj: any = {};
     if (message.rules) {
       obj.rules = message.rules.map((e) =>
-        e ? HttpRule.toJSON(e) : undefined
+        e ? HttpRule.toJSON(e) : undefined,
       );
     } else {
       obj.rules = [];
@@ -448,7 +448,7 @@ const baseHttpRule: object = { selector: '', body: '', responseBody: '' };
 export const HttpRule = {
   encode(
     message: HttpRule,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.selector !== '') {
       writer.uint32(10).string(message.selector);
@@ -471,7 +471,7 @@ export const HttpRule = {
     if (message.custom !== undefined) {
       CustomHttpPattern.encode(
         message.custom,
-        writer.uint32(66).fork()
+        writer.uint32(66).fork(),
       ).ldelim();
     }
     if (message.body !== '') {
@@ -523,7 +523,7 @@ export const HttpRule = {
           break;
         case 11:
           message.additionalBindings.push(
-            HttpRule.decode(reader, reader.uint32())
+            HttpRule.decode(reader, reader.uint32()),
           );
           break;
         default:
@@ -610,7 +610,7 @@ export const HttpRule = {
       (obj.responseBody = message.responseBody);
     if (message.additionalBindings) {
       obj.additionalBindings = message.additionalBindings.map((e) =>
-        e ? HttpRule.toJSON(e) : undefined
+        e ? HttpRule.toJSON(e) : undefined,
       );
     } else {
       obj.additionalBindings = [];
@@ -651,7 +651,7 @@ const baseCustomHttpPattern: object = { kind: '', path: '' };
 export const CustomHttpPattern = {
   encode(
     message: CustomHttpPattern,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.kind !== '') {
       writer.uint32(10).string(message.kind);
@@ -724,12 +724,12 @@ type Builtin =
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>
-  ? Array<DeepPartial<U>>
-  : T extends ReadonlyArray<infer U>
-  ? ReadonlyArray<DeepPartial<U>>
-  : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
-  : Partial<T>;
+    ? Array<DeepPartial<U>>
+    : T extends ReadonlyArray<infer U>
+      ? ReadonlyArray<DeepPartial<U>>
+      : T extends {}
+        ? { [K in keyof T]?: DeepPartial<T[K]> }
+        : Partial<T>;
 
 if (_m0.util.Long !== Long) {
   _m0.util.Long = Long as any;

--- a/src/shared/pb/google/protobuf/descriptor.ts
+++ b/src/shared/pb/google/protobuf/descriptor.ts
@@ -205,7 +205,7 @@ export enum FieldDescriptorProto_Type {
 }
 
 export function fieldDescriptorProto_TypeFromJSON(
-  object: any
+  object: any,
 ): FieldDescriptorProto_Type {
   switch (object) {
     case 1:
@@ -270,7 +270,7 @@ export function fieldDescriptorProto_TypeFromJSON(
 }
 
 export function fieldDescriptorProto_TypeToJSON(
-  object: FieldDescriptorProto_Type
+  object: FieldDescriptorProto_Type,
 ): string {
   switch (object) {
     case FieldDescriptorProto_Type.TYPE_DOUBLE:
@@ -323,7 +323,7 @@ export enum FieldDescriptorProto_Label {
 }
 
 export function fieldDescriptorProto_LabelFromJSON(
-  object: any
+  object: any,
 ): FieldDescriptorProto_Label {
   switch (object) {
     case 1:
@@ -343,7 +343,7 @@ export function fieldDescriptorProto_LabelFromJSON(
 }
 
 export function fieldDescriptorProto_LabelToJSON(
-  object: FieldDescriptorProto_Label
+  object: FieldDescriptorProto_Label,
 ): string {
   switch (object) {
     case FieldDescriptorProto_Label.LABEL_OPTIONAL:
@@ -559,7 +559,7 @@ export enum FileOptions_OptimizeMode {
 }
 
 export function fileOptions_OptimizeModeFromJSON(
-  object: any
+  object: any,
 ): FileOptions_OptimizeMode {
   switch (object) {
     case 1:
@@ -579,7 +579,7 @@ export function fileOptions_OptimizeModeFromJSON(
 }
 
 export function fileOptions_OptimizeModeToJSON(
-  object: FileOptions_OptimizeMode
+  object: FileOptions_OptimizeMode,
 ): string {
   switch (object) {
     case FileOptions_OptimizeMode.SPEED:
@@ -884,7 +884,7 @@ export enum MethodOptions_IdempotencyLevel {
 }
 
 export function methodOptions_IdempotencyLevelFromJSON(
-  object: any
+  object: any,
 ): MethodOptions_IdempotencyLevel {
   switch (object) {
     case 0:
@@ -904,7 +904,7 @@ export function methodOptions_IdempotencyLevelFromJSON(
 }
 
 export function methodOptions_IdempotencyLevelToJSON(
-  object: MethodOptions_IdempotencyLevel
+  object: MethodOptions_IdempotencyLevel,
 ): string {
   switch (object) {
     case MethodOptions_IdempotencyLevel.IDEMPOTENCY_UNKNOWN:
@@ -1133,7 +1133,7 @@ const baseFileDescriptorSet: object = {};
 export const FileDescriptorSet = {
   encode(
     message: FileDescriptorSet,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     for (const v of message.file) {
       FileDescriptorProto.encode(v!, writer.uint32(10).fork()).ldelim();
@@ -1151,7 +1151,7 @@ export const FileDescriptorSet = {
       switch (tag >>> 3) {
         case 1:
           message.file.push(
-            FileDescriptorProto.decode(reader, reader.uint32())
+            FileDescriptorProto.decode(reader, reader.uint32()),
           );
           break;
         default:
@@ -1177,7 +1177,7 @@ export const FileDescriptorSet = {
     const obj: any = {};
     if (message.file) {
       obj.file = message.file.map((e) =>
-        e ? FileDescriptorProto.toJSON(e) : undefined
+        e ? FileDescriptorProto.toJSON(e) : undefined,
       );
     } else {
       obj.file = [];
@@ -1209,7 +1209,7 @@ const baseFileDescriptorProto: object = {
 export const FileDescriptorProto = {
   encode(
     message: FileDescriptorProto,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.name !== '') {
       writer.uint32(10).string(message.name);
@@ -1248,7 +1248,7 @@ export const FileDescriptorProto = {
     if (message.sourceCodeInfo !== undefined) {
       SourceCodeInfo.encode(
         message.sourceCodeInfo,
-        writer.uint32(74).fork()
+        writer.uint32(74).fork(),
       ).ldelim();
     }
     if (message.syntax !== '') {
@@ -1302,22 +1302,22 @@ export const FileDescriptorProto = {
           break;
         case 4:
           message.messageType.push(
-            DescriptorProto.decode(reader, reader.uint32())
+            DescriptorProto.decode(reader, reader.uint32()),
           );
           break;
         case 5:
           message.enumType.push(
-            EnumDescriptorProto.decode(reader, reader.uint32())
+            EnumDescriptorProto.decode(reader, reader.uint32()),
           );
           break;
         case 6:
           message.service.push(
-            ServiceDescriptorProto.decode(reader, reader.uint32())
+            ServiceDescriptorProto.decode(reader, reader.uint32()),
           );
           break;
         case 7:
           message.extension.push(
-            FieldDescriptorProto.decode(reader, reader.uint32())
+            FieldDescriptorProto.decode(reader, reader.uint32()),
           );
           break;
         case 8:
@@ -1326,7 +1326,7 @@ export const FileDescriptorProto = {
         case 9:
           message.sourceCodeInfo = SourceCodeInfo.decode(
             reader,
-            reader.uint32()
+            reader.uint32(),
           );
           break;
         case 12:
@@ -1436,28 +1436,28 @@ export const FileDescriptorProto = {
     }
     if (message.messageType) {
       obj.messageType = message.messageType.map((e) =>
-        e ? DescriptorProto.toJSON(e) : undefined
+        e ? DescriptorProto.toJSON(e) : undefined,
       );
     } else {
       obj.messageType = [];
     }
     if (message.enumType) {
       obj.enumType = message.enumType.map((e) =>
-        e ? EnumDescriptorProto.toJSON(e) : undefined
+        e ? EnumDescriptorProto.toJSON(e) : undefined,
       );
     } else {
       obj.enumType = [];
     }
     if (message.service) {
       obj.service = message.service.map((e) =>
-        e ? ServiceDescriptorProto.toJSON(e) : undefined
+        e ? ServiceDescriptorProto.toJSON(e) : undefined,
       );
     } else {
       obj.service = [];
     }
     if (message.extension) {
       obj.extension = message.extension.map((e) =>
-        e ? FieldDescriptorProto.toJSON(e) : undefined
+        e ? FieldDescriptorProto.toJSON(e) : undefined,
       );
     } else {
       obj.extension = [];
@@ -1530,7 +1530,7 @@ export const FileDescriptorProto = {
     }
     if (object.sourceCodeInfo !== undefined && object.sourceCodeInfo !== null) {
       message.sourceCodeInfo = SourceCodeInfo.fromPartial(
-        object.sourceCodeInfo
+        object.sourceCodeInfo,
       );
     } else {
       message.sourceCodeInfo = undefined;
@@ -1545,7 +1545,7 @@ const baseDescriptorProto: object = { name: '', reservedName: '' };
 export const DescriptorProto = {
   encode(
     message: DescriptorProto,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.name !== '') {
       writer.uint32(10).string(message.name);
@@ -1565,7 +1565,7 @@ export const DescriptorProto = {
     for (const v of message.extensionRange) {
       DescriptorProto_ExtensionRange.encode(
         v!,
-        writer.uint32(42).fork()
+        writer.uint32(42).fork(),
       ).ldelim();
     }
     for (const v of message.oneofDecl) {
@@ -1577,7 +1577,7 @@ export const DescriptorProto = {
     for (const v of message.reservedRange) {
       DescriptorProto_ReservedRange.encode(
         v!,
-        writer.uint32(74).fork()
+        writer.uint32(74).fork(),
       ).ldelim();
     }
     for (const v of message.reservedName) {
@@ -1606,32 +1606,32 @@ export const DescriptorProto = {
           break;
         case 2:
           message.field.push(
-            FieldDescriptorProto.decode(reader, reader.uint32())
+            FieldDescriptorProto.decode(reader, reader.uint32()),
           );
           break;
         case 6:
           message.extension.push(
-            FieldDescriptorProto.decode(reader, reader.uint32())
+            FieldDescriptorProto.decode(reader, reader.uint32()),
           );
           break;
         case 3:
           message.nestedType.push(
-            DescriptorProto.decode(reader, reader.uint32())
+            DescriptorProto.decode(reader, reader.uint32()),
           );
           break;
         case 4:
           message.enumType.push(
-            EnumDescriptorProto.decode(reader, reader.uint32())
+            EnumDescriptorProto.decode(reader, reader.uint32()),
           );
           break;
         case 5:
           message.extensionRange.push(
-            DescriptorProto_ExtensionRange.decode(reader, reader.uint32())
+            DescriptorProto_ExtensionRange.decode(reader, reader.uint32()),
           );
           break;
         case 8:
           message.oneofDecl.push(
-            OneofDescriptorProto.decode(reader, reader.uint32())
+            OneofDescriptorProto.decode(reader, reader.uint32()),
           );
           break;
         case 7:
@@ -1639,7 +1639,7 @@ export const DescriptorProto = {
           break;
         case 9:
           message.reservedRange.push(
-            DescriptorProto_ReservedRange.decode(reader, reader.uint32())
+            DescriptorProto_ReservedRange.decode(reader, reader.uint32()),
           );
           break;
         case 10:
@@ -1721,42 +1721,42 @@ export const DescriptorProto = {
     message.name !== undefined && (obj.name = message.name);
     if (message.field) {
       obj.field = message.field.map((e) =>
-        e ? FieldDescriptorProto.toJSON(e) : undefined
+        e ? FieldDescriptorProto.toJSON(e) : undefined,
       );
     } else {
       obj.field = [];
     }
     if (message.extension) {
       obj.extension = message.extension.map((e) =>
-        e ? FieldDescriptorProto.toJSON(e) : undefined
+        e ? FieldDescriptorProto.toJSON(e) : undefined,
       );
     } else {
       obj.extension = [];
     }
     if (message.nestedType) {
       obj.nestedType = message.nestedType.map((e) =>
-        e ? DescriptorProto.toJSON(e) : undefined
+        e ? DescriptorProto.toJSON(e) : undefined,
       );
     } else {
       obj.nestedType = [];
     }
     if (message.enumType) {
       obj.enumType = message.enumType.map((e) =>
-        e ? EnumDescriptorProto.toJSON(e) : undefined
+        e ? EnumDescriptorProto.toJSON(e) : undefined,
       );
     } else {
       obj.enumType = [];
     }
     if (message.extensionRange) {
       obj.extensionRange = message.extensionRange.map((e) =>
-        e ? DescriptorProto_ExtensionRange.toJSON(e) : undefined
+        e ? DescriptorProto_ExtensionRange.toJSON(e) : undefined,
       );
     } else {
       obj.extensionRange = [];
     }
     if (message.oneofDecl) {
       obj.oneofDecl = message.oneofDecl.map((e) =>
-        e ? OneofDescriptorProto.toJSON(e) : undefined
+        e ? OneofDescriptorProto.toJSON(e) : undefined,
       );
     } else {
       obj.oneofDecl = [];
@@ -1767,7 +1767,7 @@ export const DescriptorProto = {
         : undefined);
     if (message.reservedRange) {
       obj.reservedRange = message.reservedRange.map((e) =>
-        e ? DescriptorProto_ReservedRange.toJSON(e) : undefined
+        e ? DescriptorProto_ReservedRange.toJSON(e) : undefined,
       );
     } else {
       obj.reservedRange = [];
@@ -1811,7 +1811,7 @@ export const DescriptorProto = {
     if (object.extensionRange !== undefined && object.extensionRange !== null) {
       for (const e of object.extensionRange) {
         message.extensionRange.push(
-          DescriptorProto_ExtensionRange.fromPartial(e)
+          DescriptorProto_ExtensionRange.fromPartial(e),
         );
       }
     }
@@ -1830,7 +1830,7 @@ export const DescriptorProto = {
     if (object.reservedRange !== undefined && object.reservedRange !== null) {
       for (const e of object.reservedRange) {
         message.reservedRange.push(
-          DescriptorProto_ReservedRange.fromPartial(e)
+          DescriptorProto_ReservedRange.fromPartial(e),
         );
       }
     }
@@ -1849,7 +1849,7 @@ const baseDescriptorProto_ExtensionRange: object = { start: 0, end: 0 };
 export const DescriptorProto_ExtensionRange = {
   encode(
     message: DescriptorProto_ExtensionRange,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.start !== 0) {
       writer.uint32(8).int32(message.start);
@@ -1860,7 +1860,7 @@ export const DescriptorProto_ExtensionRange = {
     if (message.options !== undefined) {
       ExtensionRangeOptions.encode(
         message.options,
-        writer.uint32(26).fork()
+        writer.uint32(26).fork(),
       ).ldelim();
     }
     return writer;
@@ -1868,7 +1868,7 @@ export const DescriptorProto_ExtensionRange = {
 
   decode(
     input: _m0.Reader | Uint8Array,
-    length?: number
+    length?: number,
   ): DescriptorProto_ExtensionRange {
     const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
@@ -1887,7 +1887,7 @@ export const DescriptorProto_ExtensionRange = {
         case 3:
           message.options = ExtensionRangeOptions.decode(
             reader,
-            reader.uint32()
+            reader.uint32(),
           );
           break;
         default:
@@ -1932,7 +1932,7 @@ export const DescriptorProto_ExtensionRange = {
   },
 
   fromPartial(
-    object: DeepPartial<DescriptorProto_ExtensionRange>
+    object: DeepPartial<DescriptorProto_ExtensionRange>,
   ): DescriptorProto_ExtensionRange {
     const message = {
       ...baseDescriptorProto_ExtensionRange,
@@ -1953,7 +1953,7 @@ const baseDescriptorProto_ReservedRange: object = { start: 0, end: 0 };
 export const DescriptorProto_ReservedRange = {
   encode(
     message: DescriptorProto_ReservedRange,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.start !== 0) {
       writer.uint32(8).int32(message.start);
@@ -1966,7 +1966,7 @@ export const DescriptorProto_ReservedRange = {
 
   decode(
     input: _m0.Reader | Uint8Array,
-    length?: number
+    length?: number,
   ): DescriptorProto_ReservedRange {
     const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
@@ -2015,7 +2015,7 @@ export const DescriptorProto_ReservedRange = {
   },
 
   fromPartial(
-    object: DeepPartial<DescriptorProto_ReservedRange>
+    object: DeepPartial<DescriptorProto_ReservedRange>,
   ): DescriptorProto_ReservedRange {
     const message = {
       ...baseDescriptorProto_ReservedRange,
@@ -2031,7 +2031,7 @@ const baseExtensionRangeOptions: object = {};
 export const ExtensionRangeOptions = {
   encode(
     message: ExtensionRangeOptions,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     for (const v of message.uninterpretedOption) {
       UninterpretedOption.encode(v!, writer.uint32(7994).fork()).ldelim();
@@ -2041,7 +2041,7 @@ export const ExtensionRangeOptions = {
 
   decode(
     input: _m0.Reader | Uint8Array,
-    length?: number
+    length?: number,
   ): ExtensionRangeOptions {
     const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
@@ -2052,7 +2052,7 @@ export const ExtensionRangeOptions = {
       switch (tag >>> 3) {
         case 999:
           message.uninterpretedOption.push(
-            UninterpretedOption.decode(reader, reader.uint32())
+            UninterpretedOption.decode(reader, reader.uint32()),
           );
           break;
         default:
@@ -2081,7 +2081,7 @@ export const ExtensionRangeOptions = {
     const obj: any = {};
     if (message.uninterpretedOption) {
       obj.uninterpretedOption = message.uninterpretedOption.map((e) =>
-        e ? UninterpretedOption.toJSON(e) : undefined
+        e ? UninterpretedOption.toJSON(e) : undefined,
       );
     } else {
       obj.uninterpretedOption = [];
@@ -2090,7 +2090,7 @@ export const ExtensionRangeOptions = {
   },
 
   fromPartial(
-    object: DeepPartial<ExtensionRangeOptions>
+    object: DeepPartial<ExtensionRangeOptions>,
   ): ExtensionRangeOptions {
     const message = { ...baseExtensionRangeOptions } as ExtensionRangeOptions;
     message.uninterpretedOption = [];
@@ -2122,7 +2122,7 @@ const baseFieldDescriptorProto: object = {
 export const FieldDescriptorProto = {
   encode(
     message: FieldDescriptorProto,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.name !== '') {
       writer.uint32(10).string(message.name);
@@ -2162,7 +2162,7 @@ export const FieldDescriptorProto = {
 
   decode(
     input: _m0.Reader | Uint8Array,
-    length?: number
+    length?: number,
   ): FieldDescriptorProto {
     const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
@@ -2320,7 +2320,7 @@ const baseOneofDescriptorProto: object = { name: '' };
 export const OneofDescriptorProto = {
   encode(
     message: OneofDescriptorProto,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.name !== '') {
       writer.uint32(10).string(message.name);
@@ -2333,7 +2333,7 @@ export const OneofDescriptorProto = {
 
   decode(
     input: _m0.Reader | Uint8Array,
-    length?: number
+    length?: number,
   ): OneofDescriptorProto {
     const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
@@ -2397,7 +2397,7 @@ const baseEnumDescriptorProto: object = { name: '', reservedName: '' };
 export const EnumDescriptorProto = {
   encode(
     message: EnumDescriptorProto,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.name !== '') {
       writer.uint32(10).string(message.name);
@@ -2411,7 +2411,7 @@ export const EnumDescriptorProto = {
     for (const v of message.reservedRange) {
       EnumDescriptorProto_EnumReservedRange.encode(
         v!,
-        writer.uint32(34).fork()
+        writer.uint32(34).fork(),
       ).ldelim();
     }
     for (const v of message.reservedName) {
@@ -2435,7 +2435,7 @@ export const EnumDescriptorProto = {
           break;
         case 2:
           message.value.push(
-            EnumValueDescriptorProto.decode(reader, reader.uint32())
+            EnumValueDescriptorProto.decode(reader, reader.uint32()),
           );
           break;
         case 3:
@@ -2445,8 +2445,8 @@ export const EnumDescriptorProto = {
           message.reservedRange.push(
             EnumDescriptorProto_EnumReservedRange.decode(
               reader,
-              reader.uint32()
-            )
+              reader.uint32(),
+            ),
           );
           break;
         case 5:
@@ -2483,7 +2483,7 @@ export const EnumDescriptorProto = {
     if (object.reservedRange !== undefined && object.reservedRange !== null) {
       for (const e of object.reservedRange) {
         message.reservedRange.push(
-          EnumDescriptorProto_EnumReservedRange.fromJSON(e)
+          EnumDescriptorProto_EnumReservedRange.fromJSON(e),
         );
       }
     }
@@ -2500,7 +2500,7 @@ export const EnumDescriptorProto = {
     message.name !== undefined && (obj.name = message.name);
     if (message.value) {
       obj.value = message.value.map((e) =>
-        e ? EnumValueDescriptorProto.toJSON(e) : undefined
+        e ? EnumValueDescriptorProto.toJSON(e) : undefined,
       );
     } else {
       obj.value = [];
@@ -2511,7 +2511,7 @@ export const EnumDescriptorProto = {
         : undefined);
     if (message.reservedRange) {
       obj.reservedRange = message.reservedRange.map((e) =>
-        e ? EnumDescriptorProto_EnumReservedRange.toJSON(e) : undefined
+        e ? EnumDescriptorProto_EnumReservedRange.toJSON(e) : undefined,
       );
     } else {
       obj.reservedRange = [];
@@ -2542,7 +2542,7 @@ export const EnumDescriptorProto = {
     if (object.reservedRange !== undefined && object.reservedRange !== null) {
       for (const e of object.reservedRange) {
         message.reservedRange.push(
-          EnumDescriptorProto_EnumReservedRange.fromPartial(e)
+          EnumDescriptorProto_EnumReservedRange.fromPartial(e),
         );
       }
     }
@@ -2561,7 +2561,7 @@ const baseEnumDescriptorProto_EnumReservedRange: object = { start: 0, end: 0 };
 export const EnumDescriptorProto_EnumReservedRange = {
   encode(
     message: EnumDescriptorProto_EnumReservedRange,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.start !== 0) {
       writer.uint32(8).int32(message.start);
@@ -2574,7 +2574,7 @@ export const EnumDescriptorProto_EnumReservedRange = {
 
   decode(
     input: _m0.Reader | Uint8Array,
-    length?: number
+    length?: number,
   ): EnumDescriptorProto_EnumReservedRange {
     const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
@@ -2623,7 +2623,7 @@ export const EnumDescriptorProto_EnumReservedRange = {
   },
 
   fromPartial(
-    object: DeepPartial<EnumDescriptorProto_EnumReservedRange>
+    object: DeepPartial<EnumDescriptorProto_EnumReservedRange>,
   ): EnumDescriptorProto_EnumReservedRange {
     const message = {
       ...baseEnumDescriptorProto_EnumReservedRange,
@@ -2639,7 +2639,7 @@ const baseEnumValueDescriptorProto: object = { name: '', number: 0 };
 export const EnumValueDescriptorProto = {
   encode(
     message: EnumValueDescriptorProto,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.name !== '') {
       writer.uint32(10).string(message.name);
@@ -2650,7 +2650,7 @@ export const EnumValueDescriptorProto = {
     if (message.options !== undefined) {
       EnumValueOptions.encode(
         message.options,
-        writer.uint32(26).fork()
+        writer.uint32(26).fork(),
       ).ldelim();
     }
     return writer;
@@ -2658,7 +2658,7 @@ export const EnumValueDescriptorProto = {
 
   decode(
     input: _m0.Reader | Uint8Array,
-    length?: number
+    length?: number,
   ): EnumValueDescriptorProto {
     const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
@@ -2719,7 +2719,7 @@ export const EnumValueDescriptorProto = {
   },
 
   fromPartial(
-    object: DeepPartial<EnumValueDescriptorProto>
+    object: DeepPartial<EnumValueDescriptorProto>,
   ): EnumValueDescriptorProto {
     const message = {
       ...baseEnumValueDescriptorProto,
@@ -2740,7 +2740,7 @@ const baseServiceDescriptorProto: object = { name: '' };
 export const ServiceDescriptorProto = {
   encode(
     message: ServiceDescriptorProto,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.name !== '') {
       writer.uint32(10).string(message.name);
@@ -2756,7 +2756,7 @@ export const ServiceDescriptorProto = {
 
   decode(
     input: _m0.Reader | Uint8Array,
-    length?: number
+    length?: number,
   ): ServiceDescriptorProto {
     const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
@@ -2770,7 +2770,7 @@ export const ServiceDescriptorProto = {
           break;
         case 2:
           message.method.push(
-            MethodDescriptorProto.decode(reader, reader.uint32())
+            MethodDescriptorProto.decode(reader, reader.uint32()),
           );
           break;
         case 3:
@@ -2810,7 +2810,7 @@ export const ServiceDescriptorProto = {
     message.name !== undefined && (obj.name = message.name);
     if (message.method) {
       obj.method = message.method.map((e) =>
-        e ? MethodDescriptorProto.toJSON(e) : undefined
+        e ? MethodDescriptorProto.toJSON(e) : undefined,
       );
     } else {
       obj.method = [];
@@ -2823,7 +2823,7 @@ export const ServiceDescriptorProto = {
   },
 
   fromPartial(
-    object: DeepPartial<ServiceDescriptorProto>
+    object: DeepPartial<ServiceDescriptorProto>,
   ): ServiceDescriptorProto {
     const message = { ...baseServiceDescriptorProto } as ServiceDescriptorProto;
     message.name = object.name ?? '';
@@ -2853,7 +2853,7 @@ const baseMethodDescriptorProto: object = {
 export const MethodDescriptorProto = {
   encode(
     message: MethodDescriptorProto,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.name !== '') {
       writer.uint32(10).string(message.name);
@@ -2878,7 +2878,7 @@ export const MethodDescriptorProto = {
 
   decode(
     input: _m0.Reader | Uint8Array,
-    length?: number
+    length?: number,
   ): MethodDescriptorProto {
     const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
@@ -2970,7 +2970,7 @@ export const MethodDescriptorProto = {
   },
 
   fromPartial(
-    object: DeepPartial<MethodDescriptorProto>
+    object: DeepPartial<MethodDescriptorProto>,
   ): MethodDescriptorProto {
     const message = { ...baseMethodDescriptorProto } as MethodDescriptorProto;
     message.name = object.name ?? '';
@@ -3013,7 +3013,7 @@ const baseFileOptions: object = {
 export const FileOptions = {
   encode(
     message: FileOptions,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.javaPackage !== '') {
       writer.uint32(10).string(message.javaPackage);
@@ -3151,7 +3151,7 @@ export const FileOptions = {
           break;
         case 999:
           message.uninterpretedOption.push(
-            UninterpretedOption.decode(reader, reader.uint32())
+            UninterpretedOption.decode(reader, reader.uint32()),
           );
           break;
         default:
@@ -3191,7 +3191,7 @@ export const FileOptions = {
       object.javaGenerateEqualsAndHash !== null
     ) {
       message.javaGenerateEqualsAndHash = Boolean(
-        object.javaGenerateEqualsAndHash
+        object.javaGenerateEqualsAndHash,
       );
     } else {
       message.javaGenerateEqualsAndHash = false;
@@ -3206,7 +3206,7 @@ export const FileOptions = {
     }
     if (object.optimizeFor !== undefined && object.optimizeFor !== null) {
       message.optimizeFor = fileOptions_OptimizeModeFromJSON(
-        object.optimizeFor
+        object.optimizeFor,
       );
     } else {
       message.optimizeFor = 1;
@@ -3355,7 +3355,7 @@ export const FileOptions = {
       (obj.rubyPackage = message.rubyPackage);
     if (message.uninterpretedOption) {
       obj.uninterpretedOption = message.uninterpretedOption.map((e) =>
-        e ? UninterpretedOption.toJSON(e) : undefined
+        e ? UninterpretedOption.toJSON(e) : undefined,
       );
     } else {
       obj.uninterpretedOption = [];
@@ -3409,7 +3409,7 @@ const baseMessageOptions: object = {
 export const MessageOptions = {
   encode(
     message: MessageOptions,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.messageSetWireFormat === true) {
       writer.uint32(8).bool(message.messageSetWireFormat);
@@ -3451,7 +3451,7 @@ export const MessageOptions = {
           break;
         case 999:
           message.uninterpretedOption.push(
-            UninterpretedOption.decode(reader, reader.uint32())
+            UninterpretedOption.decode(reader, reader.uint32()),
           );
           break;
         default:
@@ -3478,7 +3478,7 @@ export const MessageOptions = {
       object.noStandardDescriptorAccessor !== null
     ) {
       message.noStandardDescriptorAccessor = Boolean(
-        object.noStandardDescriptorAccessor
+        object.noStandardDescriptorAccessor,
       );
     } else {
       message.noStandardDescriptorAccessor = false;
@@ -3514,7 +3514,7 @@ export const MessageOptions = {
     message.mapEntry !== undefined && (obj.mapEntry = message.mapEntry);
     if (message.uninterpretedOption) {
       obj.uninterpretedOption = message.uninterpretedOption.map((e) =>
-        e ? UninterpretedOption.toJSON(e) : undefined
+        e ? UninterpretedOption.toJSON(e) : undefined,
       );
     } else {
       obj.uninterpretedOption = [];
@@ -3554,7 +3554,7 @@ const baseFieldOptions: object = {
 export const FieldOptions = {
   encode(
     message: FieldOptions,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.ctype !== 0) {
       writer.uint32(8).int32(message.ctype);
@@ -3608,7 +3608,7 @@ export const FieldOptions = {
           break;
         case 999:
           message.uninterpretedOption.push(
-            UninterpretedOption.decode(reader, reader.uint32())
+            UninterpretedOption.decode(reader, reader.uint32()),
           );
           break;
         default:
@@ -3675,7 +3675,7 @@ export const FieldOptions = {
     message.weak !== undefined && (obj.weak = message.weak);
     if (message.uninterpretedOption) {
       obj.uninterpretedOption = message.uninterpretedOption.map((e) =>
-        e ? UninterpretedOption.toJSON(e) : undefined
+        e ? UninterpretedOption.toJSON(e) : undefined,
       );
     } else {
       obj.uninterpretedOption = [];
@@ -3709,7 +3709,7 @@ const baseOneofOptions: object = {};
 export const OneofOptions = {
   encode(
     message: OneofOptions,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     for (const v of message.uninterpretedOption) {
       UninterpretedOption.encode(v!, writer.uint32(7994).fork()).ldelim();
@@ -3727,7 +3727,7 @@ export const OneofOptions = {
       switch (tag >>> 3) {
         case 999:
           message.uninterpretedOption.push(
-            UninterpretedOption.decode(reader, reader.uint32())
+            UninterpretedOption.decode(reader, reader.uint32()),
           );
           break;
         default:
@@ -3756,7 +3756,7 @@ export const OneofOptions = {
     const obj: any = {};
     if (message.uninterpretedOption) {
       obj.uninterpretedOption = message.uninterpretedOption.map((e) =>
-        e ? UninterpretedOption.toJSON(e) : undefined
+        e ? UninterpretedOption.toJSON(e) : undefined,
       );
     } else {
       obj.uninterpretedOption = [];
@@ -3784,7 +3784,7 @@ const baseEnumOptions: object = { allowAlias: false, deprecated: false };
 export const EnumOptions = {
   encode(
     message: EnumOptions,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.allowAlias === true) {
       writer.uint32(16).bool(message.allowAlias);
@@ -3814,7 +3814,7 @@ export const EnumOptions = {
           break;
         case 999:
           message.uninterpretedOption.push(
-            UninterpretedOption.decode(reader, reader.uint32())
+            UninterpretedOption.decode(reader, reader.uint32()),
           );
           break;
         default:
@@ -3855,7 +3855,7 @@ export const EnumOptions = {
     message.deprecated !== undefined && (obj.deprecated = message.deprecated);
     if (message.uninterpretedOption) {
       obj.uninterpretedOption = message.uninterpretedOption.map((e) =>
-        e ? UninterpretedOption.toJSON(e) : undefined
+        e ? UninterpretedOption.toJSON(e) : undefined,
       );
     } else {
       obj.uninterpretedOption = [];
@@ -3885,7 +3885,7 @@ const baseEnumValueOptions: object = { deprecated: false };
 export const EnumValueOptions = {
   encode(
     message: EnumValueOptions,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.deprecated === true) {
       writer.uint32(8).bool(message.deprecated);
@@ -3909,7 +3909,7 @@ export const EnumValueOptions = {
           break;
         case 999:
           message.uninterpretedOption.push(
-            UninterpretedOption.decode(reader, reader.uint32())
+            UninterpretedOption.decode(reader, reader.uint32()),
           );
           break;
         default:
@@ -3944,7 +3944,7 @@ export const EnumValueOptions = {
     message.deprecated !== undefined && (obj.deprecated = message.deprecated);
     if (message.uninterpretedOption) {
       obj.uninterpretedOption = message.uninterpretedOption.map((e) =>
-        e ? UninterpretedOption.toJSON(e) : undefined
+        e ? UninterpretedOption.toJSON(e) : undefined,
       );
     } else {
       obj.uninterpretedOption = [];
@@ -3973,7 +3973,7 @@ const baseServiceOptions: object = { deprecated: false };
 export const ServiceOptions = {
   encode(
     message: ServiceOptions,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.deprecated === true) {
       writer.uint32(264).bool(message.deprecated);
@@ -3997,7 +3997,7 @@ export const ServiceOptions = {
           break;
         case 999:
           message.uninterpretedOption.push(
-            UninterpretedOption.decode(reader, reader.uint32())
+            UninterpretedOption.decode(reader, reader.uint32()),
           );
           break;
         default:
@@ -4032,7 +4032,7 @@ export const ServiceOptions = {
     message.deprecated !== undefined && (obj.deprecated = message.deprecated);
     if (message.uninterpretedOption) {
       obj.uninterpretedOption = message.uninterpretedOption.map((e) =>
-        e ? UninterpretedOption.toJSON(e) : undefined
+        e ? UninterpretedOption.toJSON(e) : undefined,
       );
     } else {
       obj.uninterpretedOption = [];
@@ -4061,7 +4061,7 @@ const baseMethodOptions: object = { deprecated: false, idempotencyLevel: 0 };
 export const MethodOptions = {
   encode(
     message: MethodOptions,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.deprecated === true) {
       writer.uint32(264).bool(message.deprecated);
@@ -4091,7 +4091,7 @@ export const MethodOptions = {
           break;
         case 999:
           message.uninterpretedOption.push(
-            UninterpretedOption.decode(reader, reader.uint32())
+            UninterpretedOption.decode(reader, reader.uint32()),
           );
           break;
         default:
@@ -4115,7 +4115,7 @@ export const MethodOptions = {
       object.idempotencyLevel !== null
     ) {
       message.idempotencyLevel = methodOptions_IdempotencyLevelFromJSON(
-        object.idempotencyLevel
+        object.idempotencyLevel,
       );
     } else {
       message.idempotencyLevel = 0;
@@ -4136,11 +4136,11 @@ export const MethodOptions = {
     message.deprecated !== undefined && (obj.deprecated = message.deprecated);
     message.idempotencyLevel !== undefined &&
       (obj.idempotencyLevel = methodOptions_IdempotencyLevelToJSON(
-        message.idempotencyLevel
+        message.idempotencyLevel,
       ));
     if (message.uninterpretedOption) {
       obj.uninterpretedOption = message.uninterpretedOption.map((e) =>
-        e ? UninterpretedOption.toJSON(e) : undefined
+        e ? UninterpretedOption.toJSON(e) : undefined,
       );
     } else {
       obj.uninterpretedOption = [];
@@ -4176,12 +4176,12 @@ const baseUninterpretedOption: object = {
 export const UninterpretedOption = {
   encode(
     message: UninterpretedOption,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     for (const v of message.name) {
       UninterpretedOption_NamePart.encode(
         v!,
-        writer.uint32(18).fork()
+        writer.uint32(18).fork(),
       ).ldelim();
     }
     if (message.identifierValue !== '') {
@@ -4216,7 +4216,7 @@ export const UninterpretedOption = {
       switch (tag >>> 3) {
         case 2:
           message.name.push(
-            UninterpretedOption_NamePart.decode(reader, reader.uint32())
+            UninterpretedOption_NamePart.decode(reader, reader.uint32()),
           );
           break;
         case 3:
@@ -4298,7 +4298,7 @@ export const UninterpretedOption = {
     const obj: any = {};
     if (message.name) {
       obj.name = message.name.map((e) =>
-        e ? UninterpretedOption_NamePart.toJSON(e) : undefined
+        e ? UninterpretedOption_NamePart.toJSON(e) : undefined,
       );
     } else {
       obj.name = [];
@@ -4315,7 +4315,7 @@ export const UninterpretedOption = {
       (obj.stringValue = base64FromBytes(
         message.stringValue !== undefined
           ? message.stringValue
-          : new Uint8Array()
+          : new Uint8Array(),
       ));
     message.aggregateValue !== undefined &&
       (obj.aggregateValue = message.aggregateValue);
@@ -4348,7 +4348,7 @@ const baseUninterpretedOption_NamePart: object = {
 export const UninterpretedOption_NamePart = {
   encode(
     message: UninterpretedOption_NamePart,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.namePart !== '') {
       writer.uint32(10).string(message.namePart);
@@ -4361,7 +4361,7 @@ export const UninterpretedOption_NamePart = {
 
   decode(
     input: _m0.Reader | Uint8Array,
-    length?: number
+    length?: number,
   ): UninterpretedOption_NamePart {
     const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
@@ -4411,7 +4411,7 @@ export const UninterpretedOption_NamePart = {
   },
 
   fromPartial(
-    object: DeepPartial<UninterpretedOption_NamePart>
+    object: DeepPartial<UninterpretedOption_NamePart>,
   ): UninterpretedOption_NamePart {
     const message = {
       ...baseUninterpretedOption_NamePart,
@@ -4427,7 +4427,7 @@ const baseSourceCodeInfo: object = {};
 export const SourceCodeInfo = {
   encode(
     message: SourceCodeInfo,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     for (const v of message.location) {
       SourceCodeInfo_Location.encode(v!, writer.uint32(10).fork()).ldelim();
@@ -4445,7 +4445,7 @@ export const SourceCodeInfo = {
       switch (tag >>> 3) {
         case 1:
           message.location.push(
-            SourceCodeInfo_Location.decode(reader, reader.uint32())
+            SourceCodeInfo_Location.decode(reader, reader.uint32()),
           );
           break;
         default:
@@ -4471,7 +4471,7 @@ export const SourceCodeInfo = {
     const obj: any = {};
     if (message.location) {
       obj.location = message.location.map((e) =>
-        e ? SourceCodeInfo_Location.toJSON(e) : undefined
+        e ? SourceCodeInfo_Location.toJSON(e) : undefined,
       );
     } else {
       obj.location = [];
@@ -4502,7 +4502,7 @@ const baseSourceCodeInfo_Location: object = {
 export const SourceCodeInfo_Location = {
   encode(
     message: SourceCodeInfo_Location,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     writer.uint32(10).fork();
     for (const v of message.path) {
@@ -4528,7 +4528,7 @@ export const SourceCodeInfo_Location = {
 
   decode(
     input: _m0.Reader | Uint8Array,
-    length?: number
+    length?: number,
   ): SourceCodeInfo_Location {
     const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
@@ -4640,7 +4640,7 @@ export const SourceCodeInfo_Location = {
       (obj.trailingComments = message.trailingComments);
     if (message.leadingDetachedComments) {
       obj.leadingDetachedComments = message.leadingDetachedComments.map(
-        (e) => e
+        (e) => e,
       );
     } else {
       obj.leadingDetachedComments = [];
@@ -4649,7 +4649,7 @@ export const SourceCodeInfo_Location = {
   },
 
   fromPartial(
-    object: DeepPartial<SourceCodeInfo_Location>
+    object: DeepPartial<SourceCodeInfo_Location>,
   ): SourceCodeInfo_Location {
     const message = {
       ...baseSourceCodeInfo_Location,
@@ -4686,12 +4686,12 @@ const baseGeneratedCodeInfo: object = {};
 export const GeneratedCodeInfo = {
   encode(
     message: GeneratedCodeInfo,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     for (const v of message.annotation) {
       GeneratedCodeInfo_Annotation.encode(
         v!,
-        writer.uint32(10).fork()
+        writer.uint32(10).fork(),
       ).ldelim();
     }
     return writer;
@@ -4707,7 +4707,7 @@ export const GeneratedCodeInfo = {
       switch (tag >>> 3) {
         case 1:
           message.annotation.push(
-            GeneratedCodeInfo_Annotation.decode(reader, reader.uint32())
+            GeneratedCodeInfo_Annotation.decode(reader, reader.uint32()),
           );
           break;
         default:
@@ -4733,7 +4733,7 @@ export const GeneratedCodeInfo = {
     const obj: any = {};
     if (message.annotation) {
       obj.annotation = message.annotation.map((e) =>
-        e ? GeneratedCodeInfo_Annotation.toJSON(e) : undefined
+        e ? GeneratedCodeInfo_Annotation.toJSON(e) : undefined,
       );
     } else {
       obj.annotation = [];
@@ -4763,7 +4763,7 @@ const baseGeneratedCodeInfo_Annotation: object = {
 export const GeneratedCodeInfo_Annotation = {
   encode(
     message: GeneratedCodeInfo_Annotation,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     writer.uint32(10).fork();
     for (const v of message.path) {
@@ -4784,7 +4784,7 @@ export const GeneratedCodeInfo_Annotation = {
 
   decode(
     input: _m0.Reader | Uint8Array,
-    length?: number
+    length?: number,
   ): GeneratedCodeInfo_Annotation {
     const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
     let end = length === undefined ? reader.len : reader.pos + length;
@@ -4864,7 +4864,7 @@ export const GeneratedCodeInfo_Annotation = {
   },
 
   fromPartial(
-    object: DeepPartial<GeneratedCodeInfo_Annotation>
+    object: DeepPartial<GeneratedCodeInfo_Annotation>,
   ): GeneratedCodeInfo_Annotation {
     const message = {
       ...baseGeneratedCodeInfo_Annotation,
@@ -4927,12 +4927,12 @@ type Builtin =
 export type DeepPartial<T> = T extends Builtin
   ? T
   : T extends Array<infer U>
-  ? Array<DeepPartial<U>>
-  : T extends ReadonlyArray<infer U>
-  ? ReadonlyArray<DeepPartial<U>>
-  : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
-  : Partial<T>;
+    ? Array<DeepPartial<U>>
+    : T extends ReadonlyArray<infer U>
+      ? ReadonlyArray<DeepPartial<U>>
+      : T extends {}
+        ? { [K in keyof T]?: DeepPartial<T[K]> }
+        : Partial<T>;
 
 function longToNumber(long: Long): number {
   if (long.gt(Number.MAX_SAFE_INTEGER)) {

--- a/src/shared/pb/google/protobuf/timestamp.ts
+++ b/src/shared/pb/google/protobuf/timestamp.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 import Long from 'long';
-import * as _m0 from 'protobufjs/minimal';
+import _m0 from 'protobufjs/minimal';
 
 export const protobufPackage = 'google.protobuf';
 
@@ -55,7 +55,6 @@ export const protobufPackage = 'google.protobuf';
  *     Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
  *         .setNanos((int) ((millis % 1000) * 1000000)).build();
  *
- *
  * Example 5: Compute Timestamp from Java `Instant.now()`.
  *
  *     Instant now = Instant.now();
@@ -63,7 +62,6 @@ export const protobufPackage = 'google.protobuf';
  *     Timestamp timestamp =
  *         Timestamp.newBuilder().setSeconds(now.getEpochSecond())
  *             .setNanos(now.getNano()).build();
- *
  *
  * Example 6: Compute Timestamp from current time in Python.
  *
@@ -120,7 +118,7 @@ function createBaseTimestamp(): Timestamp {
 export const Timestamp = {
   encode(
     message: Timestamp,
-    writer: _m0.Writer = _m0.Writer.create()
+    writer: _m0.Writer = _m0.Writer.create(),
   ): _m0.Writer {
     if (message.seconds !== 0) {
       writer.uint32(8).int64(message.seconds);
@@ -132,43 +130,59 @@ export const Timestamp = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): Timestamp {
-    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseTimestamp();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
+          if (tag !== 8) {
+            break;
+          }
+
           message.seconds = longToNumber(reader.int64() as Long);
-          break;
+          continue;
         case 2:
+          if (tag !== 16) {
+            break;
+          }
+
           message.nanos = reader.int32();
-          break;
-        default:
-          reader.skipType(tag & 7);
-          break;
+          continue;
       }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
     }
     return message;
   },
 
   fromJSON(object: any): Timestamp {
     return {
-      seconds: isSet(object.seconds) ? Number(object.seconds) : 0,
-      nanos: isSet(object.nanos) ? Number(object.nanos) : 0,
+      seconds: isSet(object.seconds) ? globalThis.Number(object.seconds) : 0,
+      nanos: isSet(object.nanos) ? globalThis.Number(object.nanos) : 0,
     };
   },
 
   toJSON(message: Timestamp): unknown {
     const obj: any = {};
-    message.seconds !== undefined &&
-      (obj.seconds = Math.round(message.seconds));
-    message.nanos !== undefined && (obj.nanos = Math.round(message.nanos));
+    if (message.seconds !== 0) {
+      obj.seconds = Math.round(message.seconds);
+    }
+    if (message.nanos !== 0) {
+      obj.nanos = Math.round(message.nanos);
+    }
     return obj;
   },
 
+  create<I extends Exact<DeepPartial<Timestamp>, I>>(base?: I): Timestamp {
+    return Timestamp.fromPartial(base ?? ({} as any));
+  },
   fromPartial<I extends Exact<DeepPartial<Timestamp>, I>>(
-    object: I
+    object: I,
   ): Timestamp {
     const message = createBaseTimestamp();
     message.seconds = object.seconds ?? 0;
@@ -176,17 +190,6 @@ export const Timestamp = {
     return message;
   },
 };
-
-declare var self: any | undefined;
-declare var window: any | undefined;
-declare var global: any | undefined;
-var globalThis: any = (() => {
-  if (typeof globalThis !== 'undefined') return globalThis;
-  if (typeof self !== 'undefined') return self;
-  if (typeof window !== 'undefined') return window;
-  if (typeof global !== 'undefined') return global;
-  throw 'Unable to locate global object';
-})();
 
 type Builtin =
   | Date
@@ -199,24 +202,23 @@ type Builtin =
 
 export type DeepPartial<T> = T extends Builtin
   ? T
-  : T extends Array<infer U>
-  ? Array<DeepPartial<U>>
-  : T extends ReadonlyArray<infer U>
-  ? ReadonlyArray<DeepPartial<U>>
-  : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
-  : Partial<T>;
+  : T extends globalThis.Array<infer U>
+    ? globalThis.Array<DeepPartial<U>>
+    : T extends ReadonlyArray<infer U>
+      ? ReadonlyArray<DeepPartial<U>>
+      : T extends {}
+        ? { [K in keyof T]?: DeepPartial<T[K]> }
+        : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 export type Exact<P, I extends P> = P extends Builtin
   ? P
-  : P & { [K in keyof P]: Exact<P[K], I[K]> } & Record<
-        Exclude<keyof I, KeysOfUnion<P>>,
-        never
-      >;
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & {
+      [K in Exclude<keyof I, KeysOfUnion<P>>]: never;
+    };
 
 function longToNumber(long: Long): number {
-  if (long.gt(Number.MAX_SAFE_INTEGER)) {
+  if (long.gt(globalThis.Number.MAX_SAFE_INTEGER)) {
     throw new globalThis.Error('Value is larger than Number.MAX_SAFE_INTEGER');
   }
   return long.toNumber();

--- a/src/trayMenu/helper.ts
+++ b/src/trayMenu/helper.ts
@@ -142,6 +142,14 @@ export default class Helper {
     });
 
     template.push({
+      label: 'Load Connections',
+      click() {
+        appWindow?.webContents.send('redirectTo', '/loadForm');
+        appWindow?.show();
+      },
+    });
+
+    template.push({
       label: 'Manage Connections',
       click() {
         appWindow?.webContents.send('redirectTo', '/manage');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1226,10 +1226,10 @@
   resolved "https://registry.yarnpkg.com/@babel/regjsgen/-/regjsgen-0.8.0.tgz#f0ba69b075e1f05fb2825b7fad991e7adbb18310"
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
-"@babel/runtime@^7.12.5", "@babel/runtime@^7.18.3", "@babel/runtime@^7.20.7", "@babel/runtime@^7.21.0", "@babel/runtime@^7.23.2", "@babel/runtime@^7.23.8", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
-  version "7.23.8"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.8.tgz#8ee6fe1ac47add7122902f257b8ddf55c898f650"
-  integrity sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.18.3", "@babel/runtime@^7.20.7", "@babel/runtime@^7.21.0", "@babel/runtime@^7.23.2", "@babel/runtime@^7.23.8", "@babel/runtime@^7.26.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+  version "7.26.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.7.tgz#f4e7fe527cd710f8dc0618610b61b4b060c3c341"
+  integrity sha512-AOPI3D+a8dXnja+iwsUqGRjr1BbZIe771sXdapOtYI531gSqpi92vXivKcq2asu/DFpdl1ceFAKZyRzK2PCVcQ==
   dependencies:
     regenerator-runtime "^0.14.0"
 
@@ -1878,6 +1878,13 @@
   version "5.15.5"
   resolved "https://registry.yarnpkg.com/@mui/core-downloads-tracker/-/core-downloads-tracker-5.15.5.tgz#e8e060133ea0e92b1c0e30c441522cab37d0be79"
   integrity sha512-VhT8klyXy8GrWrARqLMoM6Nzz809Jc3Wn5wd7WOZfre2vFO1rBV1dBANAPBhBqpaQI0HCMRTWEYoSyOFgRnz4A==
+
+"@mui/icons-material@^6.4.1":
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/@mui/icons-material/-/icons-material-6.4.1.tgz#e12f2a93bd5226aa65258533b7161f156b515b8d"
+  integrity sha512-wsxFcUTQxt4s+7Bg4GgobqRjyaHLmZGNOs+HJpbwrwmLbT6mhIJxhpqsKzzWq9aDY8xIe7HCjhpH7XI5UD6teA==
+  dependencies:
+    "@babel/runtime" "^7.26.0"
 
 "@mui/lab@^5.0.0-alpha.161":
   version "5.0.0-alpha.161"

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,7 +25,7 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.22.13", "@babel/code-frame@^7.23.5", "@babel/code-frame@^7.25.9", "@babel/code-frame@^7.26.2":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.23.5", "@babel/code-frame@^7.25.9", "@babel/code-frame@^7.26.2":
   version "7.26.2"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.26.2.tgz#4b5fab97d33338eff916235055f0ebc21e573a85"
   integrity sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==
@@ -235,7 +235,7 @@
   dependencies:
     "@babel/types" "^7.22.5"
 
-"@babel/helper-string-parser@^7.23.4", "@babel/helper-string-parser@^7.25.9":
+"@babel/helper-string-parser@^7.25.9":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz#1aabb72ee72ed35789b4bbcad3ca2862ce614e8c"
   integrity sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==
@@ -268,16 +268,7 @@
     "@babel/traverse" "^7.23.7"
     "@babel/types" "^7.23.6"
 
-"@babel/highlight@^7.23.4":
-  version "7.23.4"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.23.4.tgz#edaadf4d8232e1a961432db785091207ead0621b"
-  integrity sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.22.20"
-    chalk "^2.4.2"
-    js-tokens "^4.0.0"
-
-"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.22.15", "@babel/parser@^7.23.6", "@babel/parser@^7.25.9", "@babel/parser@^7.26.2", "@babel/parser@^7.26.5", "@babel/parser@^7.7.0":
+"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.23.6", "@babel/parser@^7.25.9", "@babel/parser@^7.26.2", "@babel/parser@^7.26.5", "@babel/parser@^7.7.0":
   version "7.26.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.26.5.tgz#6fec9aebddef25ca57a935c86dbb915ae2da3e1f"
   integrity sha512-SRJ4jYmXRqV1/Xc+TIVG84WjHBXKlxO9sHQnA2Pf12QQEAp1LOh6kDzNHXcUnbH1QI0FDoPPVOt+vyUDucxpaw==
@@ -1788,7 +1779,7 @@
     "@types/yargs" "^17.0.8"
     chalk "^4.0.0"
 
-"@jridgewell/gen-mapping@^0.3.0", "@jridgewell/gen-mapping@^0.3.2", "@jridgewell/gen-mapping@^0.3.5":
+"@jridgewell/gen-mapping@^0.3.0", "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.8"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz#4f0e06362e01362f823d348f1872b08f666d8142"
   integrity sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==
@@ -1802,7 +1793,7 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz#c08679063f279615a3326583ba3a90d1d82cc721"
   integrity sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==
 
-"@jridgewell/set-array@^1.0.1", "@jridgewell/set-array@^1.2.1":
+"@jridgewell/set-array@^1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.2.1.tgz#558fb6472ed16a4c850b889530e6b36438c49280"
   integrity sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==
@@ -1828,7 +1819,7 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.17", "@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.20", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25", "@jridgewell/trace-mapping@^0.3.9":
+"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.20", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25", "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.25"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz#15f190e98895f3fc23276ee14bc76b675c2e50f0"
   integrity sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==
@@ -3583,13 +3574,6 @@ ansi-regex@^6.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.1.0.tgz#95ec409c69619d6cb1b8b34f14b660ef28ebd654"
   integrity sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==
 
-ansi-styles@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
-  integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
-  dependencies:
-    color-convert "^1.9.0"
-
 ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
@@ -4314,15 +4298,6 @@ chainsaw@~0.1.0:
   dependencies:
     traverse ">=0.3.0 <0.4"
 
-chalk@^2.4.2:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
-  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
-  dependencies:
-    ansi-styles "^3.2.1"
-    escape-string-regexp "^1.0.5"
-    supports-color "^5.3.0"
-
 chalk@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
@@ -4479,24 +4454,12 @@ collect-v8-coverage@^1.0.0:
   resolved "https://registry.yarnpkg.com/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz#cc2c8e94fc18bbdffe64d6534570c8a673b27f59"
   integrity sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==
 
-color-convert@^1.9.0:
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
-  integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
-  dependencies:
-    color-name "1.1.3"
-
 color-convert@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
   integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
   dependencies:
     color-name "~1.1.4"
-
-color-name@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
-  integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
 color-name@~1.1.4:
   version "1.1.4"
@@ -5645,11 +5608,6 @@ escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
 
-escape-string-regexp@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
-  integrity sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==
-
 escape-string-regexp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
@@ -6651,11 +6609,6 @@ has-bigints@^1.0.1, has-bigints@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
   integrity sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==
-
-has-flag@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
-  integrity sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==
 
 has-flag@^4.0.0:
   version "4.0.0"
@@ -7785,11 +7738,6 @@ jsbn@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-1.1.0.tgz#b01307cb29b618a1ed26ec79e911f803c4da0040"
   integrity sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==
-
-jsesc@^2.5.1:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
-  integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
 jsesc@^3.0.2:
   version "3.1.0"
@@ -10598,13 +10546,6 @@ sumchecker@^3.0.1:
   dependencies:
     debug "^4.1.0"
 
-supports-color@^5.3.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
-  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
-  dependencies:
-    has-flag "^3.0.0"
-
 supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
@@ -10752,11 +10693,6 @@ tmpl@1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.5.tgz#8683e0b902bb9c20c4f726e3c0b69f36518c07cc"
   integrity sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==
-
-to-fast-properties@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
-  integrity sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==
 
 to-regex-range@^5.0.1:
   version "5.0.1"
@@ -11068,6 +11004,13 @@ url-loader@^4.1.1:
     loader-utils "^2.0.0"
     mime-types "^2.1.27"
     schema-utils "^3.0.0"
+
+usehooks-ts@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/usehooks-ts/-/usehooks-ts-3.1.0.tgz#156119f36efc85f1b1952616c02580f140950eca"
+  integrity sha512-bBIa7yUyPhE1BCc0GmR96VU/15l/9gP1Ch5mYdLcFBaFGQsdmXkvjV0TtOqW1yUd6VjIwDunm+flSciCQXujiw==
+  dependencies:
+    lodash.debounce "^4.0.8"
 
 utf8-byte-length@^1.0.1:
   version "1.0.4"


### PR DESCRIPTION
## Summary

This adds a new form to load connections from a Pomerium URL using the new routes discovery portal. TCP and UDP connections will be created automatically.

I attempted to make it preserve any manually edited settings that aren't directly set by the load form (like the listener address).

The Load Form has an advanced section similar to the regular form. Those connection options will be used for each of the created connections. (For example to disable TLS)

The inputs on this form are saved into local storage so the user can reload their connections quickly.

Other changes:

* the API protobuf was regenerated based on changes from https://github.com/pomerium/cli/pull/487
* I noticed while testing that loading the routes was a little racy, so I added some async helpers so we can wait for the save to complete before reloading all the routes again
* The "New Connection" button was changed into a pop-over. This was mostly copied from the zero ui.
* I pulled out the `TagSelector` into a component
* I added some spacing between the header and forms on some of the pages. The buttons seemed to close to the border of the form.

## Related issues
- Fixes ENG-1879


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
