### PR TITLE
(feat) add the ability to automatically run connections on startup

### DIFF
--- a/api.proto
+++ b/api.proto
@@ -263,4 +263,5 @@ message Connection {
   reserved 8; // unreleased client_cert_issuer_cn search criterion
   // indicates to search the system trust store for a client certificate
   optional ClientCertFromStore client_cert_from_store = 9;
+  optional bool autostart = 11;
 }

--- a/src/main.dev.ts
+++ b/src/main.dev.ts
@@ -351,6 +351,26 @@ async function init(): Promise<void> {
       cliProcess.kill('SIGINT');
       mainWindow?.close();
     });
+
+    // Auto-start connections marked with autostart flag
+    configClient.list({ all: true, ids: [], tags: [] }, (err, res) => {
+      if (!err && res) {
+        const autoStartIds = res.records
+          .filter((r) => r.conn && r.conn.autostart)
+          .map((r) => r.id);
+        if (autoStartIds.length > 0) {
+          listenerClient.update(
+            { connectionIds: autoStartIds, connected: true },
+            (err, res) => {
+              if (!err && res) {
+                trayMenuHelper.setStatuses(res.listeners);
+                menu.tray.setContextMenu(trayMenuHelper.createContextMenu());
+              }
+            },
+          );
+        }
+      }
+    });
   });
 }
 

--- a/src/main.dev.ts
+++ b/src/main.dev.ts
@@ -361,10 +361,11 @@ async function init(): Promise<void> {
         if (autoStartIds.length > 0) {
           listenerClient.update(
             { connectionIds: autoStartIds, connected: true },
-            (err, res) => {
-              if (!err && res) {
-                trayMenuHelper.setStatuses(res.listeners);
+            (updateErr, updateRes) => {
+              if (!updateErr && updateRes) {
+                trayMenuHelper.setStatuses(updateRes.listeners);
                 menu.tray.setContextMenu(trayMenuHelper.createContextMenu());
+                console.log('Auto-started connections:', autoStartIds);
               }
             },
           );

--- a/src/renderer/pages/ConnectForm.tsx
+++ b/src/renderer/pages/ConnectForm.tsx
@@ -3,8 +3,10 @@ import {
   Button,
   CardContent,
   Container,
+  FormControlLabel,
   Grid,
   Stack,
+  Switch,
   Typography,
 } from '@mui/material';
 import { ipcRenderer } from 'electron';
@@ -42,6 +44,7 @@ const initialConnData: Connection = {
   caCert: undefined,
   clientCert: undefined,
   clientCertFromStore: undefined,
+  autostart: false,
 };
 
 const ConnectForm: FC<Props> = () => {
@@ -198,6 +201,20 @@ const ConnectForm: FC<Props> = () => {
                     onChange={(evt): void => saveLocal(evt.target.value)}
                     variant="outlined"
                     helperText="The port or local address you want to connect to. Ex. :8888 or 127.0.0.1:8888"
+                  />
+                </Grid>
+                <Grid item xs={12}>
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        checked={connection.autostart || false}
+                        onChange={(evt) =>
+                          setConnection({ ...connection, autostart: evt.target.checked })
+                        }
+                        color="primary"
+                      />
+                    }
+                    label="Start connection at app launch"
                   />
                 </Grid>
                 <Grid item xs={12}>

--- a/src/renderer/pages/ConnectForm.tsx
+++ b/src/renderer/pages/ConnectForm.tsx
@@ -209,7 +209,10 @@ const ConnectForm: FC<Props> = () => {
                       <Switch
                         checked={connection.autostart || false}
                         onChange={(evt) =>
-                          setConnection({ ...connection, autostart: evt.target.checked })
+                          setConnection({
+                            ...connection,
+                            autostart: evt.target.checked,
+                          })
                         }
                         color="primary"
                       />

--- a/src/shared/pb/api.ts
+++ b/src/shared/pb/api.ts
@@ -400,6 +400,7 @@ export interface Connection {
   clientCert?: Certificate | undefined;
   /** indicates to search the system trust store for a client certificate */
   clientCertFromStore?: ClientCertFromStore | undefined;
+  autostart?: boolean | undefined;
 }
 
 function createBaseRecord(): Record {
@@ -3281,6 +3282,7 @@ function createBaseConnection(): Connection {
     caCert: undefined,
     clientCert: undefined,
     clientCertFromStore: undefined,
+    autostart: undefined,
   };
 }
 
@@ -3318,6 +3320,9 @@ export const Connection = {
         message.clientCertFromStore,
         writer.uint32(74).fork(),
       ).ldelim();
+    }
+    if (message.autostart !== undefined) {
+      writer.uint32(88).bool(message.autostart);
     }
     return writer;
   },
@@ -3396,6 +3401,13 @@ export const Connection = {
             reader.uint32(),
           );
           continue;
+        case 11:
+          if (tag !== 88) {
+            break;
+          }
+
+          message.autostart = reader.bool();
+          continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -3429,6 +3441,9 @@ export const Connection = {
         : undefined,
       clientCertFromStore: isSet(object.clientCertFromStore)
         ? ClientCertFromStore.fromJSON(object.clientCertFromStore)
+        : undefined,
+      autostart: isSet(object.autostart)
+        ? globalThis.Boolean(object.autostart)
         : undefined,
     };
   },
@@ -3464,6 +3479,9 @@ export const Connection = {
         message.clientCertFromStore,
       );
     }
+    if (message.autostart !== undefined) {
+      obj.autostart = message.autostart;
+    }
     return obj;
   },
 
@@ -3490,6 +3508,7 @@ export const Connection = {
       object.clientCertFromStore !== null
         ? ClientCertFromStore.fromPartial(object.clientCertFromStore)
         : undefined;
+    message.autostart = object.autostart ?? undefined;
     return message;
   },
 };


### PR DESCRIPTION
## Summary

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->
![Screenshot 2025-02-27 at 3 50 55 PM](https://github.com/user-attachments/assets/89394aed-2ab3-4dfb-a5e1-4f7b6c403eb0)
Adds the abitlity to set connections to start on app launch within Pomerium Desktop. 
## Related issues
Relies on https://github.com/pomerium/cli/pull/494
<!-- For example...
Fixes #159
-->


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
