### PR TITLE
Explicitly target the Windows package to use --x64 flag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,4 +53,4 @@ jobs:
           yarn release -m --x64
           yarn release -l --arm64
           yarn release -l --x64
-          yarn release -w
+          yarn release -w --x64

--- a/src/package.json
+++ b/src/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pomerium-desktop",
   "productName": "pomerium-desktop",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "description": "Cross Platform Desktop Application for establishing TCP connections through Pomerium",
   "main": "./main.prod.js",
   "author": {


### PR DESCRIPTION
## Summary
https://pomerium-com.slack.com/archives/C012D1Q96TX/p1744312102858289?thread_ts=1744116868.986989&cid=C012D1Q96TX

## Related issues
https://linear.app/pomerium/issue/ENG-2220/not-able-to-upgrade-to-version-0290


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
