### PR TITLE
Update CI to not constantly attempt to release the app

### DIFF
--- a/.github/workflows/actions-lint.yaml
+++ b/.github/workflows/actions-lint.yaml
@@ -1,0 +1,28 @@
+name: lint workflows
+
+on:
+  push:
+    paths:
+      - ".github/workflows/"
+  pull_request:
+    branches:
+      - "main"
+
+jobs:
+  lint-workflows:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: Install action-validator with asdf
+        uses: asdf-vm/actions/install@v4
+        with:
+          tool_versions: |
+            action-validator 0.5.1
+
+      - name: Lint Actions
+        run: |
+          find .github/workflows -type f \( -iname \*.yaml -o -iname \*.yml \) \
+            | xargs -I {} action-validator --verbose {}  

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,32 @@
+name: Publish
+permissions:
+  contents: read
+on:
+  push:
+
+jobs:
+  build:
+    permissions:
+      contents: read 
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Install Node, NPM and Yarn
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 20.6.1
+
+      - name: Install dependencies
+        run: |
+          yarn install
+
+      - name: build
+        run: |
+          yarn package -m --arm64
+          yarn package -m --x64
+          yarn package -l --arm64
+          yarn package -l --x64
+          yarn package -w --x64

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,7 @@ name: Publish
 permissions:
   contents: read
 on:
-  push:
-    branches: ['main']
+  release:
 
 jobs:
   publish:


### PR DESCRIPTION
- moves publish to only run on releases
- creates a build workflow that runs on each push, but doesn't sign or release the app
- ci lint action that checks changes to the github actions file is valid.

## Summary

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
Fixes #159
-->


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
