### PR TITLE
fix: add "--" to npm run release calls in publish workflow to forward flags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,8 +49,8 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_KEY_ISSUER: ${{ secrets.APPLE_ID_KEY_ISSUER }}
         run: |
-          npm run release -m --arm64
-          npm run release -m --x64
-          npm run release -l --arm64
-          npm run release -l --x64
-          npm run release -w --x64
+          npm run release -- -m --arm64
+          npm run release -- -m --x64
+          npm run release -- -l --arm64
+          npm run release -- -l --x64
+          npm run release -- -w --x64


### PR DESCRIPTION
## Summary

Moving to npm worked, but I wasn't properly forwarding flags for the release script in the publish workflow.

```bash
existingType=release publishingType=draft
  • skipped publishing  file=Pomerium-Desktop-0.31.0-arm64.dmg reason=existing type not compatible with publishing type tag=v0.31.0 version=0.31.0 existingType=release publishingType=draft
  • skipped publishing  file=latest-mac.yml reason=existing type not compatible with publishing type tag=v0.31.0 version=0.31.0 existingType=release publishingType=draft
npm error No workspaces found:
npm error   --workspace=--x64
npm error A complete log of this run can be found in: /Users/runner/.npm/_logs/2025-11-04T03_44_09_730Z-debug-0.log
Error: Process completed with exit code 1.
```

Now the publish workflow should work once this is merged.

## Related issues

Relates to #467


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
