### PR TITLE
Bump pomeriumCli dependency to 0.32.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -305,6 +305,6 @@
     }
   },
   "pomeriumCli": {
-    "version": "v0.31.0"
+    "version": "v0.32.0"
   }
 }


### PR DESCRIPTION
## Summary

Bumps the CLI dependency to v0.32.0

## Related issues

<!-- For example...
Fixes #159
-->


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
