### PR TITLE
update 'tar' from 7.5.7 to 7.5.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19948,9 +19948,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
-      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
+      "integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -265,7 +265,7 @@
     "validator": "^13.15.22"
   },
   "overrides": {
-    "tar": "^7.5.7"
+    "tar": "^7.5.11"
   },
   "engines": {
     "node": ">=20",


### PR DESCRIPTION
## Summary

Update the 'tar' package to address a number of dependabot alerts.

I'm not totally sure why dependabot is not able to update this automatically? There is an `overrides` entry for this package to avoid a transitive dependency issue, so maybe that's preventing dependabot from succeeding.

## Related issues

- https://github.com/pomerium/desktop-client/security/dependabot/182
- https://github.com/pomerium/desktop-client/security/dependabot/202
- https://github.com/pomerium/desktop-client/security/dependabot/203


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
