### PR TITLE
ci: harden JS dependency supply chain

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,3 +9,12 @@ updates:
       github-actions:
         patterns:
           - '*'
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 50
+    groups:
+      npm:
+        patterns:
+          - '*'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,18 @@
+name: Dependency Review
+on:
+  pull_request:
+    paths:
+      - "**/package.json"
+      - "**/package-lock.json"
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48
+        with:
+          fail-on-severity: high

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,7 +12,7 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:
           fail-on-severity: high

--- a/.github/workflows/npm-audit-signatures.yml
+++ b/.github/workflows/npm-audit-signatures.yml
@@ -17,8 +17,8 @@ jobs:
   audit-signatures:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: .tool-versions
       - run: npm ci --ignore-scripts

--- a/.github/workflows/npm-audit-signatures.yml
+++ b/.github/workflows/npm-audit-signatures.yml
@@ -1,0 +1,25 @@
+name: NPM Audit Signatures
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**/package.json"
+      - "**/package-lock.json"
+  pull_request:
+    paths:
+      - "**/package.json"
+      - "**/package-lock.json"
+
+permissions:
+  contents: read
+
+jobs:
+  audit-signatures:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238
+        with:
+          node-version-file: .tool-versions
+      - run: npm ci --ignore-scripts
+      - run: npm audit signatures

--- a/package.json
+++ b/package.json
@@ -284,6 +284,7 @@
     "@tootallnate/once": ">=3.0.1",
     "diff": ">=5.2.2"
   },
+  "packageManager": "npm@10.9.4",
   "engines": {
     "node": ">=20",
     "npm": ">=10",


### PR DESCRIPTION
## Summary

Part of ENG-3808. Adds standardized JS supply-chain controls to desktop-client.

- Pin `npm@10.9.4` in `package.json`
- Extend `.github/dependabot.yaml` to cover npm dependencies
- Add `.github/workflows/dependency-review.yml`
- Add `.github/workflows/npm-audit-signatures.yml`
- Keep actions SHA-pinned with readable tag comments and refresh `actions/setup-node` to `v6.3.0`

The existing `.npmrc` with `legacy-peer-deps=true` is preserved and remains required for installs.

AI-assisted: drafted by Claude, verified locally, reviewed by Codex.

## Test plan

- [x] `dependency-review` triggers and passes on this PR
- [x] `npm-audit-signatures` triggers and passes on this PR
- [x] Existing CI on this PR passes
- [ ] Confirm Dependabot opens npm dependency PRs on the next scheduled cycle
- [ ] Validate the `packageManager` field in a fresh Corepack-based install path
