### PR TITLE
npm 11.12.1 + min-release-age=3

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,3 +9,12 @@ updates:
       github-actions:
         patterns:
           - '*'
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 50
+    groups:
+      npm:
+        patterns:
+          - '*'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,11 @@ jobs:
           node-version-file: .tool-versions
 
       - name: Install npm 11.12.1 (npm 10 ignores min-release-age)
-        run: npm install --global npm@11.12.1
+        run: |
+          npm_dir="$(npm root -g)/npm"
+          rm -rf "$npm_dir"
+          mkdir -p "$npm_dir"
+          curl -fsSL "https://registry.npmjs.org/npm/-/npm-11.12.1.tgz" | tar xz --strip-components=1 -C "$npm_dir"
       - name: Verify npm version
         run: npm --version
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,6 +26,11 @@ jobs:
         with:
           node-version-file: .tool-versions
 
+      - name: Install npm 11.12.1 (npm 10 ignores min-release-age)
+        run: npm install --global npm@11.12.1
+      - name: Verify npm version
+        run: npm --version
+
       - name: Install dependencies
         run: |
           npm ci

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,18 @@
+name: Dependency Review
+on:
+  pull_request:
+    paths:
+      - "**/package.json"
+      - "**/package-lock.json"
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48
+        with:
+          fail-on-severity: high

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,7 +12,7 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:
           fail-on-severity: high

--- a/.github/workflows/npm-audit-signatures.yml
+++ b/.github/workflows/npm-audit-signatures.yml
@@ -30,4 +30,4 @@ jobs:
       - name: Verify npm version
         run: npm --version
       - run: npm ci --ignore-scripts
-      - run: npm audit signatures
+      - run: npm audit signatures --min-release-age=0

--- a/.github/workflows/npm-audit-signatures.yml
+++ b/.github/workflows/npm-audit-signatures.yml
@@ -17,8 +17,8 @@ jobs:
   audit-signatures:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: .tool-versions
       - run: npm ci --ignore-scripts

--- a/.github/workflows/npm-audit-signatures.yml
+++ b/.github/workflows/npm-audit-signatures.yml
@@ -22,7 +22,11 @@ jobs:
         with:
           node-version-file: .tool-versions
       - name: Install npm 11.12.1 (npm 10 ignores min-release-age)
-        run: npm install --global npm@11.12.1
+        run: |
+          npm_dir="$(npm root -g)/npm"
+          rm -rf "$npm_dir"
+          mkdir -p "$npm_dir"
+          curl -fsSL "https://registry.npmjs.org/npm/-/npm-11.12.1.tgz" | tar xz --strip-components=1 -C "$npm_dir"
       - name: Verify npm version
         run: npm --version
       - run: npm ci --ignore-scripts

--- a/.github/workflows/npm-audit-signatures.yml
+++ b/.github/workflows/npm-audit-signatures.yml
@@ -21,5 +21,9 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: .tool-versions
+      - name: Install npm 11.12.1 (npm 10 ignores min-release-age)
+        run: npm install --global npm@11.12.1
+      - name: Verify npm version
+        run: npm --version
       - run: npm ci --ignore-scripts
       - run: npm audit signatures

--- a/.github/workflows/npm-audit-signatures.yml
+++ b/.github/workflows/npm-audit-signatures.yml
@@ -1,0 +1,25 @@
+name: NPM Audit Signatures
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**/package.json"
+      - "**/package-lock.json"
+  pull_request:
+    paths:
+      - "**/package.json"
+      - "**/package-lock.json"
+
+permissions:
+  contents: read
+
+jobs:
+  audit-signatures:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238
+        with:
+          node-version-file: .tool-versions
+      - run: npm ci --ignore-scripts
+      - run: npm audit signatures

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,11 @@ jobs:
           node-version-file: .tool-versions
 
       - name: Install npm 11.12.1 (npm 10 ignores min-release-age)
-        run: npm install --global npm@11.12.1
+        run: |
+          npm_dir="$(npm root -g)/npm"
+          rm -rf "$npm_dir"
+          mkdir -p "$npm_dir"
+          curl -fsSL "https://registry.npmjs.org/npm/-/npm-11.12.1.tgz" | tar xz --strip-components=1 -C "$npm_dir"
       - name: Verify npm version
         run: npm --version
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,11 @@ jobs:
         with:
           node-version-file: .tool-versions
 
+      - name: Install npm 11.12.1 (npm 10 ignores min-release-age)
+        run: npm install --global npm@11.12.1
+      - name: Verify npm version
+        run: npm --version
+
       - name: Install dependencies
         run: |
           npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,11 @@ jobs:
         with:
           node-version-file: .tool-versions
 
+      - name: Install npm 11.12.1 (npm 10 ignores min-release-age)
+        run: npm install --global npm@11.12.1
+      - name: Verify npm version
+        run: npm --version
+
       - name: npm ci
         run: |
           npm ci --network-timeout 300000

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,11 @@ jobs:
           node-version-file: .tool-versions
 
       - name: Install npm 11.12.1 (npm 10 ignores min-release-age)
-        run: npm install --global npm@11.12.1
+        run: |
+          npm_dir="$(npm root -g)/npm"
+          rm -rf "$npm_dir"
+          mkdir -p "$npm_dir"
+          curl -fsSL "https://registry.npmjs.org/npm/-/npm-11.12.1.tgz" | tar xz --strip-components=1 -C "$npm_dir"
       - name: Verify npm version
         run: npm --version
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
 legacy-peer-deps=true
+; npm 11+ required: npm 10 silently ignores min-release-age
+min-release-age=3

--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 ## Get all the dependencies
 
+Requires npm 11.12.1 (`npm install -g npm@11.12.1`). npm 10 silently ignores the `min-release-age` package-age gate.
+
 ```bash
-npm install
+npm ci
 ```
 
 ## Development checkout of pomerium-cli

--- a/package.json
+++ b/package.json
@@ -284,6 +284,7 @@
     "@tootallnate/once": ">=3.0.1",
     "diff": ">=5.2.2"
   },
+  "packageManager": "npm@10.9.4",
   "engines": {
     "node": ">=20",
     "npm": ">=10",

--- a/package.json
+++ b/package.json
@@ -284,10 +284,10 @@
     "@tootallnate/once": ">=3.0.1",
     "diff": ">=5.2.2"
   },
-  "packageManager": "npm@10.9.4",
+  "packageManager": "npm@11.12.1",
   "engines": {
     "node": ">=20",
-    "npm": ">=10",
+    "npm": ">=11 <12",
     "yarn": "YARN NO LONGER USED - use npm instead."
   },
   "browserslist": [],


### PR DESCRIPTION
## Summary

- Upgrade `packageManager` from `npm@10.9.4` to `npm@11.12.1`
- Tighten `engines.npm` from `>=10` to `>=11 <12`
- Add `min-release-age=3` to `.npmrc` (preserves existing `legacy-peer-deps=true`)
- Update CI workflows (`build.yaml`, `test.yml`, `publish.yml`, `npm-audit-signatures.yml`) to explicitly install npm 11.12.1 after `actions/setup-node`
- Update README: `npm install` -> `npm ci`, add npm 11.12.1 version note

No dependency versions changed. No lockfiles rewritten. Verified zero lockfile drift.

Part of ENG-3817. AI-drafted, manually reviewed.

## Test plan

- [ ] CI passes on this PR
- [ ] `npm ci --ignore-scripts` works
- [ ] No unexpected `package-lock.json` changes
- [ ] First post-merge Dependabot npm PR opens normally