### PR TITLE
chore: bump pomerium cli to 0.32.2 / bump desktop version 0.32.2

### DIFF
--- a/.github/workflows/actions-lint.yaml
+++ b/.github/workflows/actions-lint.yaml
@@ -3,7 +3,7 @@ name: lint workflows
 on:
   push:
     paths:
-      - '.github/workflows/'
+      - '.github/workflows/**'
   pull_request:
     branches:
       - 'main'

--- a/package.json
+++ b/package.json
@@ -325,6 +325,6 @@
     }
   },
   "pomeriumCli": {
-    "version": "v0.32.0"
+    "version": "v0.32.2"
   }
 }

--- a/src/package.json
+++ b/src/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pomerium-desktop",
   "productName": "pomerium-desktop",
-  "version": "0.32.1",
+  "version": "0.32.2",
   "description": "Cross Platform Desktop Application for establishing TCP connections through Pomerium",
   "main": "./main.prod.js",
   "author": {


### PR DESCRIPTION
## Summary

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
Fixes #159
-->


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
