### PR TITLE
ci: bump Node to 24.14.1

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 action-validator 0.9.0
-nodejs 20.20.2
+nodejs 24.14.1

--- a/package.json
+++ b/package.json
@@ -215,7 +215,7 @@
       "minimatch": ">=9.0.7"
     }
   },
-  "packageManager": "npm@10.9.4",
+  "packageManager": "npm@11.11.0",
   "engines": {
     "node": ">=20",
     "npm": ">=10",


### PR DESCRIPTION
Bumps `.tool-versions` nodejs to **24.14.1** (LTS, ships npm 11.11.0).

Pre-work for https://linear.app/pomerium/issue/ENG-3817 — with npm 11 in CI, enabling the `min-release-age` package-age gate later is a one-line `.npmrc` change.

_AI-drafted, human-reviewed._