### PR TITLE
chore: bump pomerium/cli to v0.33.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -257,6 +257,6 @@
     }
   },
   "pomeriumCli": {
-    "version": "v0.32.2"
+    "version": "v0.33.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pomerium-desktop",
-  "version": "0.32.2",
+  "version": "0.33.0",
   "productName": "PomeriumDesktop",
   "description": "Cross Platform Desktop Application for establishing TCP connections through Pomerium",
   "main": "out/main/index.js",


### PR DESCRIPTION
## Summary

Bumping pomerium/cli to v0.33.0 for v0.33.0 desktop release

## Related issues

[ENG-4179](https://linear.app/pomerium/issue/ENG-4179/v0330-desktop)

## Checklist

- [X] reference any related issues
- [X] updated docs
- [X] updated unit tests
- [X] updated UPGRADING.md
- [X] add appropriate tag (`improvement` / `bug` / etc)
- [X] ready for review
