### PR TITLE
fix(ci): fix latest release action

### DIFF
--- a/.github/workflows/notify-tap.yml
+++ b/.github/workflows/notify-tap.yml
@@ -9,11 +9,10 @@ jobs:
 
     steps:
       - id: get_latest
-        uses: pozetroninc/github-action-get-latest-release@2a61c339ea7ef0a336d1daa35ef0cb1418e7676c
+        uses: rez0n/actions-github-release@05fabbd6b2b3ce3383299555ea518faea69b736d
         with:
           repository: ${{ github.repository }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          excludes: prerelease, draft
+          type: 'stable'
 
       - id: clean_versions
         run: |


### PR DESCRIPTION
## Summary
Switch to a different github action to determine the latest release. The current one was return v0.21 for some reason.

- [ENG-4262](https://linear.app/pomerium/issue/ENG-4262/operations-homebrew-tap-still-on-v32)

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
