### PR TITLE
feat: add Chocolatey and WinGet integration

### DIFF
--- a/.github/workflows/windows-package-managers.yml
+++ b/.github/workflows/windows-package-managers.yml
@@ -1,0 +1,105 @@
+name: Windows package managers
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/workflows/windows-package-managers.yml"
+      - "package.json"
+      - "package-lock.json"
+      - "scripts/GenerateWindowsPackageMetadata.ts"
+      - "scripts/GenerateWindowsPackageMetadata.test.ts"
+      - "scripts/fixtures/windows-package-metadata/**"
+      - "scripts/windows-package-managers/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate ${{ matrix.package-manager }}
+    runs-on: windows-2025
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package-manager: chocolatey
+            harness-package-manager: Chocolatey
+          - package-manager: winget
+            harness-package-manager: WinGet
+
+    env:
+      EVIDENCE_DIRECTORY: output/windows-package-managers/evidence/${{ matrix.package-manager }}
+      HARNESS_PACKAGE_MANAGER: ${{ matrix.harness-package-manager }}
+      PREVIOUS_METADATA_DIRECTORY: output/windows-package-managers/metadata/0.32.2
+      CURRENT_METADATA_DIRECTORY: output/windows-package-managers/metadata/0.33.0
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .tool-versions
+
+      - name: Install dependencies
+        run: npm ci --network-timeout 300000
+
+      - name: Generate v0.32.2 package metadata
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          npm run package-managers:generate --
+          --tag v0.32.2
+          --output $env:PREVIOUS_METADATA_DIRECTORY
+
+      - name: Generate v0.33.0 package metadata
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          npm run package-managers:generate --
+          --tag v0.33.0
+          --output $env:CURRENT_METADATA_DIRECTORY
+
+      - name: Bootstrap WinGet
+        if: ${{ matrix.package-manager == 'winget' }}
+        shell: pwsh
+        run: |
+          if (-not (Get-Command winget.exe -ErrorAction SilentlyContinue)) {
+            Install-Module -Name Microsoft.WinGet.Client -Force -Repository PSGallery -Scope CurrentUser | Out-Null
+            Repair-WinGetPackageManager -AllUsers
+          }
+
+          # Delivery Optimization is not reliably available on hosted runners, and winget reports
+          # its absence as 0x8A15006D while downloading the installer.
+          $settingsPath = Join-Path $env:LOCALAPPDATA "Packages\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\LocalState\settings.json"
+          New-Item -ItemType Directory -Force -Path (Split-Path $settingsPath) | Out-Null
+          @{ '$schema' = 'https://aka.ms/winget-settings.schema.json'; network = @{ downloader = 'wininet' } } |
+            ConvertTo-Json | Set-Content -Encoding utf8 $settingsPath
+
+          winget --info
+          winget settings export
+
+      - name: Test package lifecycle
+        shell: pwsh
+        run: >-
+          ./scripts/windows-package-managers/Test-WindowsPackageLifecycle.ps1
+          -PackageManager $env:HARNESS_PACKAGE_MANAGER
+          -OldMetadataRoot $env:PREVIOUS_METADATA_DIRECTORY
+          -NewMetadataRoot $env:CURRENT_METADATA_DIRECTORY
+          -EvidenceDirectory $env:EVIDENCE_DIRECTORY
+
+      - name: Upload package evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: windows-package-managers-${{ matrix.package-manager }}
+          path: output/windows-package-managers
+          if-no-files-found: warn
+          retention-days: 14

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pomerium-desktop",
       "version": "0.33.0",
       "hasInstallScript": true,
-      "license": "MIT",
+      "license": "Apache-2.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "bugs": {
     "url": "https://github.com/pomerium/desktop-client/issues"
   },
-  "license": "MIT",
+  "license": "Apache-2.0",
   "author": {
     "name": "Pomerium Inc",
     "email": "info@pomerium.com",
@@ -38,6 +38,7 @@
     "dev-setup": "git clone https://github.com/pomerium/cli && ln -s $(pwd)/cli/bin/pomerium-cli assets/bin/ && cd cli && make build && npm run metadata",
     "build-cli": "cd cli && git pull origin; make build",
     "metadata": "npx tsx scripts/WriteMetadata.ts",
+    "package-managers:generate": "tsx scripts/GenerateWindowsPackageMetadata.ts",
     "lint": "oxlint .",
     "format": "oxfmt .",
     "format:check": "oxfmt --check .",

--- a/scripts/GenerateWindowsPackageMetadata.test.ts
+++ b/scripts/GenerateWindowsPackageMetadata.test.ts
@@ -1,0 +1,193 @@
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import releaseFixture from "./fixtures/windows-package-metadata/github-release-v0.33.0.json";
+import {
+  fetchWindowsRelease,
+  renderWindowsPackageMetadata,
+  resolveWindowsRelease,
+  writeWindowsPackageMetadata,
+} from "./GenerateWindowsPackageMetadata";
+
+const tag = "v0.33.0";
+const release = resolveWindowsRelease(releaseFixture, tag);
+const goldenDirectory = path.join(
+  import.meta.dirname,
+  "fixtures",
+  "windows-package-metadata",
+  "golden-v0.33.0",
+);
+
+const readGoldenFiles = (directory: string, baseDirectory = directory): Map<string, string> => {
+  const files = new Map<string, string>();
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      for (const [relativePath, contents] of readGoldenFiles(entryPath, baseDirectory)) {
+        files.set(relativePath, contents);
+      }
+    } else {
+      files.set(
+        path.relative(baseDirectory, entryPath).split(path.sep).join("/"),
+        readFileSync(entryPath, "utf8"),
+      );
+    }
+  }
+  return files;
+};
+
+describe("Windows release resolver", () => {
+  it("resolves the exact stable GitHub release and normalizes its digest", () => {
+    expect(release).toEqual({
+      tag: "v0.33.0",
+      version: "0.33.0",
+      installerName: "Pomerium-Desktop-Setup-0.33.0.exe",
+      installerUrl:
+        "https://github.com/pomerium/desktop-client/releases/download/v0.33.0/Pomerium-Desktop-Setup-0.33.0.exe",
+      installerSha256: "6B889F360650019B910FDA8CCA04B3F17C51A6AAB55DF44215DE8EF0FE68800E",
+      installerSize: 125556122,
+      releaseDate: "2026-07-16",
+    });
+  });
+
+  it.each([
+    ["a tag that is not an exact stable version", releaseFixture, "0.33.0", "stable exact tag"],
+    ["a release whose tag moved", { ...releaseFixture, tag_name: "v0.33.1" }, tag, "must equal"],
+    ["a draft release", { ...releaseFixture, draft: true }, tag, "published and stable"],
+    ["a prerelease", { ...releaseFixture, prerelease: true }, tag, "published and stable"],
+    ["an unpublished release", { ...releaseFixture, published_at: null }, tag, "published_at"],
+    ["a release with no assets", { ...releaseFixture, assets: [] }, tag, "exactly one"],
+    [
+      "a release with two matching installers",
+      { ...releaseFixture, assets: [releaseFixture.assets[0], releaseFixture.assets[0]] },
+      tag,
+      "exactly one",
+    ],
+    [
+      "an installer that is still uploading",
+      { ...releaseFixture, assets: [{ ...releaseFixture.assets[0], state: "new" }] },
+      tag,
+      "must be uploaded",
+    ],
+    [
+      "an installer served from another host",
+      {
+        ...releaseFixture,
+        assets: [
+          { ...releaseFixture.assets[0], browser_download_url: "https://example.com/app.exe" },
+        ],
+      },
+      tag,
+      "asset URL must be",
+    ],
+    [
+      "an installer with no digest",
+      { ...releaseFixture, assets: [{ ...releaseFixture.assets[0], digest: null }] },
+      tag,
+      "must have a SHA-256 digest",
+    ],
+    [
+      "an installer digested with another algorithm",
+      {
+        ...releaseFixture,
+        assets: [{ ...releaseFixture.assets[0], digest: `sha512:${"a".repeat(128)}` }],
+      },
+      tag,
+      "must have a SHA-256 digest",
+    ],
+    [
+      "an installer with a malformed digest",
+      {
+        ...releaseFixture,
+        assets: [{ ...releaseFixture.assets[0], digest: "sha256:not-a-digest" }],
+      },
+      tag,
+      "64 hexadecimal characters",
+    ],
+    [
+      "an installer with no byte size",
+      { ...releaseFixture, assets: [{ ...releaseFixture.assets[0], size: null }] },
+      tag,
+      "positive byte size",
+    ],
+  ])("rejects %s", (_name, payload, exactTag, message) => {
+    expect(() => resolveWindowsRelease(payload, exactTag)).toThrow(message);
+  });
+
+  it("fetches only the requested GitHub release tag", async () => {
+    const fetcher = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => releaseFixture,
+    }));
+
+    await expect(fetchWindowsRelease(tag, fetcher, "test-token")).resolves.toEqual(release);
+    expect(fetcher).toHaveBeenCalledOnce();
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://api.github.com/repos/pomerium/desktop-client/releases/tags/v0.33.0",
+      {
+        headers: {
+          Accept: "application/vnd.github+json",
+          Authorization: "Bearer test-token",
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+      },
+    );
+  });
+
+  it("reports a failed GitHub release request", async () => {
+    const fetcher = vi.fn(async () => ({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+      json: async () => ({}),
+    }));
+
+    await expect(fetchWindowsRelease(tag, fetcher)).rejects.toThrow(
+      "failed to fetch GitHub release v0.33.0: 404 Not Found",
+    );
+  });
+});
+
+describe("Windows package metadata", () => {
+  it("matches the reviewed golden package files", () => {
+    expect(renderWindowsPackageMetadata(release)).toEqual(readGoldenFiles(goldenDirectory));
+  });
+
+  it("writes the package roots and the release descriptor the harness reads", () => {
+    const outputDirectory = mkdtempSync(path.join(tmpdir(), "pomerium-package-managers-"));
+
+    try {
+      writeWindowsPackageMetadata(release, outputDirectory);
+
+      expect(readdirSync(outputDirectory).sort()).toEqual(["chocolatey", "release.json", "winget"]);
+      expect(JSON.parse(readFileSync(path.join(outputDirectory, "release.json"), "utf8"))).toEqual(
+        release,
+      );
+    } finally {
+      rmSync(outputDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves no earlier version behind when a directory is reused", () => {
+    const outputDirectory = mkdtempSync(path.join(tmpdir(), "pomerium-package-managers-"));
+    const olderRelease = { ...release, version: "0.32.2", tag: "v0.32.2" };
+
+    try {
+      writeWindowsPackageMetadata(olderRelease, outputDirectory);
+      writeWindowsPackageMetadata(release, outputDirectory);
+
+      expect(
+        readdirSync(
+          path.join(outputDirectory, "winget", "manifests", "p", "Pomerium", "PomeriumDesktop"),
+        ),
+      ).toEqual(["0.33.0"]);
+    } finally {
+      rmSync(outputDirectory, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/GenerateWindowsPackageMetadata.ts
+++ b/scripts/GenerateWindowsPackageMetadata.ts
@@ -1,0 +1,350 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { parseArgs } from "node:util";
+
+const githubRepository = "pomerium/desktop-client";
+const packageIdentifier = "Pomerium.PomeriumDesktop";
+const packageName = "Pomerium Desktop";
+const packageDescription =
+  "Cross-platform desktop application for establishing TCP connections through Pomerium.";
+const productCode = "1f7d9fda-695d-5026-9065-253047710988";
+const stableTagPattern = /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/;
+const sha256Pattern = /^[0-9a-f]{64}$/i;
+
+export type WindowsRelease = {
+  readonly tag: string;
+  readonly version: string;
+  readonly installerName: string;
+  readonly installerUrl: string;
+  readonly installerSha256: string;
+  readonly installerSize: number;
+  readonly releaseDate: string;
+};
+
+type GitHubReleaseAsset = {
+  name?: unknown;
+  browser_download_url?: unknown;
+  digest?: unknown;
+  state?: unknown;
+  size?: unknown;
+};
+
+type GitHubRelease = {
+  tag_name?: unknown;
+  draft?: unknown;
+  prerelease?: unknown;
+  published_at?: unknown;
+  assets?: unknown;
+};
+
+export type ReleaseFetcher = (
+  input: string,
+  init: { headers: Record<string, string> },
+) => Promise<Pick<Response, "ok" | "status" | "statusText" | "json">>;
+
+const parseStableTag = (tag: string) => {
+  if (!stableTagPattern.test(tag)) {
+    throw new Error(`release tag must be a stable exact tag in the form vX.Y.Z: ${tag}`);
+  }
+  return tag.slice(1);
+};
+
+const parseReleaseDate = (publishedAt: unknown) => {
+  if (
+    typeof publishedAt !== "string" ||
+    !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(publishedAt)
+  ) {
+    throw new Error(`GitHub release must have a published_at timestamp: ${String(publishedAt)}`);
+  }
+  return publishedAt.slice(0, 10);
+};
+
+const getReleaseAsset = (release: GitHubRelease, expectedFileName: string) => {
+  if (!Array.isArray(release.assets)) {
+    throw new Error("GitHub release assets must be an array");
+  }
+
+  const matches = release.assets.filter(
+    (asset): asset is GitHubReleaseAsset =>
+      typeof asset === "object" && asset !== null && asset.name === expectedFileName,
+  );
+  if (matches.length !== 1) {
+    throw new Error(
+      `GitHub release must contain exactly one ${expectedFileName} asset; found ${matches.length}`,
+    );
+  }
+  return matches[0];
+};
+
+export const resolveWindowsRelease = (payload: unknown, exactTag: string): WindowsRelease => {
+  const version = parseStableTag(exactTag);
+  if (typeof payload !== "object" || payload === null) {
+    throw new Error("GitHub release response must be an object");
+  }
+
+  const release = payload as GitHubRelease;
+  if (release.tag_name !== exactTag) {
+    throw new Error(`GitHub release tag must equal ${exactTag}`);
+  }
+  if (release.draft !== false || release.prerelease !== false) {
+    throw new Error(`GitHub release ${exactTag} must be published and stable`);
+  }
+
+  const releaseDate = parseReleaseDate(release.published_at);
+  const expectedFileName = `Pomerium-Desktop-Setup-${version}.exe`;
+  const expectedUrl = `https://github.com/${githubRepository}/releases/download/${exactTag}/${expectedFileName}`;
+  const asset = getReleaseAsset(release, expectedFileName);
+
+  if (asset.state !== "uploaded") {
+    throw new Error(`GitHub release asset ${expectedFileName} must be uploaded`);
+  }
+  if (asset.browser_download_url !== expectedUrl) {
+    throw new Error(`GitHub release asset URL must be ${expectedUrl}`);
+  }
+  if (typeof asset.digest !== "string" || !asset.digest.startsWith("sha256:")) {
+    throw new Error(`GitHub release asset ${expectedFileName} must have a SHA-256 digest`);
+  }
+
+  const installerSha256 = asset.digest.slice("sha256:".length);
+  if (!sha256Pattern.test(installerSha256)) {
+    throw new Error("GitHub release asset SHA-256 must contain 64 hexadecimal characters");
+  }
+  if (typeof asset.size !== "number" || !Number.isSafeInteger(asset.size) || asset.size <= 0) {
+    throw new Error(`GitHub release asset ${expectedFileName} must have a positive byte size`);
+  }
+
+  return {
+    tag: exactTag,
+    version,
+    installerName: expectedFileName,
+    installerUrl: expectedUrl,
+    installerSha256: installerSha256.toUpperCase(),
+    installerSize: asset.size,
+    releaseDate,
+  };
+};
+
+export const fetchWindowsRelease = async (
+  exactTag: string,
+  fetcher: ReleaseFetcher = fetch,
+  githubToken = process.env.GITHUB_TOKEN,
+): Promise<WindowsRelease> => {
+  parseStableTag(exactTag);
+
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  if (githubToken) {
+    headers.Authorization = `Bearer ${githubToken}`;
+  }
+
+  const response = await fetcher(
+    `https://api.github.com/repos/${githubRepository}/releases/tags/${exactTag}`,
+    { headers },
+  );
+  if (!response.ok) {
+    throw new Error(
+      `failed to fetch GitHub release ${exactTag}: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  return resolveWindowsRelease(await response.json(), exactTag);
+};
+
+const renderChocolateyNuspec = (release: WindowsRelease) => `<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>pomerium-desktop</id>
+    <version>${release.version}</version>
+    <title>${packageName}</title>
+    <authors>Pomerium Inc</authors>
+    <owners>Pomerium Inc</owners>
+    <projectUrl>https://github.com/pomerium/desktop-client</projectUrl>
+    <projectSourceUrl>https://github.com/pomerium/desktop-client</projectSourceUrl>
+    <packageSourceUrl>https://github.com/pomerium/desktop-client/blob/main/scripts/GenerateWindowsPackageMetadata.ts</packageSourceUrl>
+    <iconUrl>https://raw.githubusercontent.com/pomerium/desktop-client/v${release.version}/assets/icons/128x128.png</iconUrl>
+    <licenseUrl>https://github.com/pomerium/desktop-client/blob/v${release.version}/LICENSE</licenseUrl>
+    <bugTrackerUrl>https://github.com/pomerium/desktop-client/issues</bugTrackerUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>${packageDescription}</description>
+    <summary>Connect to services through Pomerium from the Windows desktop.</summary>
+    <releaseNotes>https://github.com/pomerium/desktop-client/releases/tag/v${release.version}</releaseNotes>
+    <copyright>Copyright Pomerium Inc</copyright>
+    <tags>pomerium zero-trust networking desktop windows</tags>
+  </metadata>
+  <files>
+    <file src="tools\\**" target="tools" />
+  </files>
+</package>
+`;
+
+const renderChocolateyInstall = (release: WindowsRelease) => `$ErrorActionPreference = 'Stop'
+
+$packageArgs = @{
+  packageName    = $env:ChocolateyPackageName
+  fileType       = 'exe'
+  url64bit       = '${release.installerUrl}'
+  checksum64     = '${release.installerSha256}'
+  checksumType64 = 'sha256'
+  silentArgs     = '/S'
+  validExitCodes = @(0)
+}
+
+Install-ChocolateyPackage @packageArgs
+`;
+
+const chocolateyUninstall = `$ErrorActionPreference = 'Stop'
+
+$softwareName = 'Pomerium Desktop*'
+$registryKeys = @(Get-UninstallRegistryKey -SoftwareName $softwareName)
+
+if ($registryKeys.Count -eq 0) {
+  Write-Warning "$softwareName is not installed."
+  return
+}
+if ($registryKeys.Count -ne 1) {
+  throw "Found $($registryKeys.Count) uninstall entries for $softwareName."
+}
+
+$uninstallCommand = [string]$registryKeys[0].UninstallString
+if ($uninstallCommand -notmatch '^"(?<file>[^"]+\\.exe)"(?:\\s.*)?$') {
+  throw "The uninstall command has an unexpected format: $uninstallCommand"
+}
+
+$packageArgs = @{
+  packageName    = $env:ChocolateyPackageName
+  fileType       = 'exe'
+  silentArgs     = '/currentuser /S'
+  file           = $Matches.file
+  validExitCodes = @(0)
+}
+
+Uninstall-ChocolateyPackage @packageArgs
+`;
+
+const renderChocolateyPackage = (release: WindowsRelease) =>
+  new Map<string, string>([
+    ["chocolatey/pomerium-desktop.nuspec", renderChocolateyNuspec(release)],
+    ["chocolatey/tools/chocolateyInstall.ps1", renderChocolateyInstall(release)],
+    ["chocolatey/tools/chocolateyUninstall.ps1", chocolateyUninstall],
+  ]);
+
+const renderWingetVersion = (
+  release: WindowsRelease,
+) => `# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: ${packageIdentifier}
+PackageVersion: ${release.version}
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0
+`;
+
+const renderWingetInstaller = (
+  release: WindowsRelease,
+) => `# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: ${packageIdentifier}
+PackageVersion: ${release.version}
+InstallerType: nullsoft
+Scope: user
+ElevationRequirement: elevationProhibited
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: ${release.releaseDate}
+Installers:
+  - Architecture: x64
+    ProductCode: ${productCode}
+    InstallerUrl: ${release.installerUrl}
+    InstallerSha256: ${release.installerSha256}
+    AppsAndFeaturesEntries:
+      - DisplayName: ${packageName} ${release.version}
+        Publisher: Pomerium Inc
+        ProductCode: ${productCode}
+ManifestType: installer
+ManifestVersion: 1.10.0
+`;
+
+const renderWingetLocale = (
+  release: WindowsRelease,
+) => `# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: ${packageIdentifier}
+PackageVersion: ${release.version}
+PackageLocale: en-US
+Publisher: Pomerium Inc
+PublisherUrl: https://www.pomerium.com/
+PublisherSupportUrl: https://github.com/pomerium/desktop-client/issues
+Author: Pomerium Inc
+PackageName: ${packageName}
+PackageUrl: https://github.com/pomerium/desktop-client
+License: Apache-2.0
+LicenseUrl: https://github.com/pomerium/desktop-client/blob/v${release.version}/LICENSE
+Copyright: Copyright Pomerium Inc
+ShortDescription: Connect to services through Pomerium from the Windows desktop.
+Description: ${packageDescription}
+Moniker: pomerium-desktop
+Tags:
+  - access
+  - networking
+  - security
+  - zero-trust
+ReleaseNotesUrl: https://github.com/pomerium/desktop-client/releases/tag/v${release.version}
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0
+`;
+
+const renderWingetPackage = (release: WindowsRelease) => {
+  const wingetBase = `winget/manifests/p/Pomerium/PomeriumDesktop/${release.version}`;
+  return new Map<string, string>([
+    [`${wingetBase}/${packageIdentifier}.yaml`, renderWingetVersion(release)],
+    [`${wingetBase}/${packageIdentifier}.installer.yaml`, renderWingetInstaller(release)],
+    [`${wingetBase}/${packageIdentifier}.locale.en-US.yaml`, renderWingetLocale(release)],
+  ]);
+};
+
+export const renderWindowsPackageMetadata = (release: WindowsRelease) =>
+  new Map([...renderChocolateyPackage(release), ...renderWingetPackage(release)]);
+
+export const writeWindowsPackageMetadata = (release: WindowsRelease, outputDirectory: string) => {
+  // WinGet manifests live under a per-version path, so writing a second version into the same
+  // directory would leave both behind and give the harness two installer manifests to choose from.
+  for (const packageRoot of ["chocolatey", "winget"]) {
+    rmSync(path.join(outputDirectory, packageRoot), { recursive: true, force: true });
+  }
+
+  for (const [relativePath, contents] of renderWindowsPackageMetadata(release)) {
+    const outputPath = path.join(outputDirectory, ...relativePath.split("/"));
+    mkdirSync(path.dirname(outputPath), { recursive: true });
+    writeFileSync(outputPath, contents, "utf8");
+  }
+  writeFileSync(
+    path.join(outputDirectory, "release.json"),
+    `${JSON.stringify(release, null, 2)}\n`,
+    "utf8",
+  );
+};
+
+const main = async () => {
+  const { values } = parseArgs({
+    options: { tag: { type: "string" }, output: { type: "string" } },
+  });
+  if (!values.tag || !values.output) {
+    throw new Error("usage: --tag vX.Y.Z --output <directory>");
+  }
+
+  const release = await fetchWindowsRelease(values.tag);
+  writeWindowsPackageMetadata(release, values.output);
+};
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  void main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/fixtures/windows-package-metadata/github-release-v0.33.0.json
+++ b/scripts/fixtures/windows-package-metadata/github-release-v0.33.0.json
@@ -1,0 +1,15 @@
+{
+  "tag_name": "v0.33.0",
+  "draft": false,
+  "prerelease": false,
+  "published_at": "2026-07-16T22:37:23Z",
+  "assets": [
+    {
+      "name": "Pomerium-Desktop-Setup-0.33.0.exe",
+      "browser_download_url": "https://github.com/pomerium/desktop-client/releases/download/v0.33.0/Pomerium-Desktop-Setup-0.33.0.exe",
+      "digest": "sha256:6b889f360650019b910fda8cca04b3f17c51a6aab55df44215de8ef0fe68800e",
+      "state": "uploaded",
+      "size": 125556122
+    }
+  ]
+}

--- a/scripts/fixtures/windows-package-metadata/golden-v0.33.0/chocolatey/pomerium-desktop.nuspec
+++ b/scripts/fixtures/windows-package-metadata/golden-v0.33.0/chocolatey/pomerium-desktop.nuspec
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>pomerium-desktop</id>
+    <version>0.33.0</version>
+    <title>Pomerium Desktop</title>
+    <authors>Pomerium Inc</authors>
+    <owners>Pomerium Inc</owners>
+    <projectUrl>https://github.com/pomerium/desktop-client</projectUrl>
+    <projectSourceUrl>https://github.com/pomerium/desktop-client</projectSourceUrl>
+    <packageSourceUrl>https://github.com/pomerium/desktop-client/blob/main/scripts/GenerateWindowsPackageMetadata.ts</packageSourceUrl>
+    <iconUrl>https://raw.githubusercontent.com/pomerium/desktop-client/v0.33.0/assets/icons/128x128.png</iconUrl>
+    <licenseUrl>https://github.com/pomerium/desktop-client/blob/v0.33.0/LICENSE</licenseUrl>
+    <bugTrackerUrl>https://github.com/pomerium/desktop-client/issues</bugTrackerUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Cross-platform desktop application for establishing TCP connections through Pomerium.</description>
+    <summary>Connect to services through Pomerium from the Windows desktop.</summary>
+    <releaseNotes>https://github.com/pomerium/desktop-client/releases/tag/v0.33.0</releaseNotes>
+    <copyright>Copyright Pomerium Inc</copyright>
+    <tags>pomerium zero-trust networking desktop windows</tags>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/scripts/fixtures/windows-package-metadata/golden-v0.33.0/chocolatey/tools/chocolateyInstall.ps1
+++ b/scripts/fixtures/windows-package-metadata/golden-v0.33.0/chocolatey/tools/chocolateyInstall.ps1
@@ -1,0 +1,13 @@
+$ErrorActionPreference = 'Stop'
+
+$packageArgs = @{
+  packageName    = $env:ChocolateyPackageName
+  fileType       = 'exe'
+  url64bit       = 'https://github.com/pomerium/desktop-client/releases/download/v0.33.0/Pomerium-Desktop-Setup-0.33.0.exe'
+  checksum64     = '6B889F360650019B910FDA8CCA04B3F17C51A6AAB55DF44215DE8EF0FE68800E'
+  checksumType64 = 'sha256'
+  silentArgs     = '/S'
+  validExitCodes = @(0)
+}
+
+Install-ChocolateyPackage @packageArgs

--- a/scripts/fixtures/windows-package-metadata/golden-v0.33.0/chocolatey/tools/chocolateyUninstall.ps1
+++ b/scripts/fixtures/windows-package-metadata/golden-v0.33.0/chocolatey/tools/chocolateyUninstall.ps1
@@ -1,0 +1,27 @@
+$ErrorActionPreference = 'Stop'
+
+$softwareName = 'Pomerium Desktop*'
+$registryKeys = @(Get-UninstallRegistryKey -SoftwareName $softwareName)
+
+if ($registryKeys.Count -eq 0) {
+  Write-Warning "$softwareName is not installed."
+  return
+}
+if ($registryKeys.Count -ne 1) {
+  throw "Found $($registryKeys.Count) uninstall entries for $softwareName."
+}
+
+$uninstallCommand = [string]$registryKeys[0].UninstallString
+if ($uninstallCommand -notmatch '^"(?<file>[^"]+\.exe)"(?:\s.*)?$') {
+  throw "The uninstall command has an unexpected format: $uninstallCommand"
+}
+
+$packageArgs = @{
+  packageName    = $env:ChocolateyPackageName
+  fileType       = 'exe'
+  silentArgs     = '/currentuser /S'
+  file           = $Matches.file
+  validExitCodes = @(0)
+}
+
+Uninstall-ChocolateyPackage @packageArgs

--- a/scripts/fixtures/windows-package-metadata/golden-v0.33.0/winget/manifests/p/Pomerium/PomeriumDesktop/0.33.0/Pomerium.PomeriumDesktop.installer.yaml
+++ b/scripts/fixtures/windows-package-metadata/golden-v0.33.0/winget/manifests/p/Pomerium/PomeriumDesktop/0.33.0/Pomerium.PomeriumDesktop.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: Pomerium.PomeriumDesktop
+PackageVersion: 0.33.0
+InstallerType: nullsoft
+Scope: user
+ElevationRequirement: elevationProhibited
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: 2026-07-16
+Installers:
+  - Architecture: x64
+    ProductCode: 1f7d9fda-695d-5026-9065-253047710988
+    InstallerUrl: https://github.com/pomerium/desktop-client/releases/download/v0.33.0/Pomerium-Desktop-Setup-0.33.0.exe
+    InstallerSha256: 6B889F360650019B910FDA8CCA04B3F17C51A6AAB55DF44215DE8EF0FE68800E
+    AppsAndFeaturesEntries:
+      - DisplayName: Pomerium Desktop 0.33.0
+        Publisher: Pomerium Inc
+        ProductCode: 1f7d9fda-695d-5026-9065-253047710988
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/scripts/fixtures/windows-package-metadata/golden-v0.33.0/winget/manifests/p/Pomerium/PomeriumDesktop/0.33.0/Pomerium.PomeriumDesktop.locale.en-US.yaml
+++ b/scripts/fixtures/windows-package-metadata/golden-v0.33.0/winget/manifests/p/Pomerium/PomeriumDesktop/0.33.0/Pomerium.PomeriumDesktop.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: Pomerium.PomeriumDesktop
+PackageVersion: 0.33.0
+PackageLocale: en-US
+Publisher: Pomerium Inc
+PublisherUrl: https://www.pomerium.com/
+PublisherSupportUrl: https://github.com/pomerium/desktop-client/issues
+Author: Pomerium Inc
+PackageName: Pomerium Desktop
+PackageUrl: https://github.com/pomerium/desktop-client
+License: Apache-2.0
+LicenseUrl: https://github.com/pomerium/desktop-client/blob/v0.33.0/LICENSE
+Copyright: Copyright Pomerium Inc
+ShortDescription: Connect to services through Pomerium from the Windows desktop.
+Description: Cross-platform desktop application for establishing TCP connections through Pomerium.
+Moniker: pomerium-desktop
+Tags:
+  - access
+  - networking
+  - security
+  - zero-trust
+ReleaseNotesUrl: https://github.com/pomerium/desktop-client/releases/tag/v0.33.0
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/scripts/fixtures/windows-package-metadata/golden-v0.33.0/winget/manifests/p/Pomerium/PomeriumDesktop/0.33.0/Pomerium.PomeriumDesktop.yaml
+++ b/scripts/fixtures/windows-package-metadata/golden-v0.33.0/winget/manifests/p/Pomerium/PomeriumDesktop/0.33.0/Pomerium.PomeriumDesktop.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: Pomerium.PomeriumDesktop
+PackageVersion: 0.33.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0

--- a/scripts/windows-package-managers/Test-WindowsPackageLifecycle.ps1
+++ b/scripts/windows-package-managers/Test-WindowsPackageLifecycle.ps1
@@ -1,0 +1,478 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [ValidateSet("Chocolatey", "WinGet")]
+  [string]$PackageManager,
+
+  [Parameter(Mandatory = $true)]
+  [string]$OldMetadataRoot,
+
+  [Parameter(Mandatory = $true)]
+  [string]$NewMetadataRoot,
+
+  [Parameter(Mandatory = $true)]
+  [string]$EvidenceDirectory
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+if (Test-Path Variable:PSNativeCommandUseErrorActionPreference) {
+  $PSNativeCommandUseErrorActionPreference = $false
+}
+
+$script:RepositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+$script:EvidenceDirectory = [System.IO.Path]::GetFullPath($EvidenceDirectory)
+$script:Assertions = [System.Collections.Generic.List[object]]::new()
+$script:Commands = [System.Collections.Generic.List[object]]::new()
+$script:StartedAt = [DateTime]::UtcNow
+$script:LifecycleCompleted = $false
+$script:Failure = $null
+# electron-builder derives this UUIDv5 from the io.pomerium.PomeriumDesktop application ID.
+$script:ProductCode = "1f7d9fda-695d-5026-9065-253047710988"
+$script:PackageIdentifier = "Pomerium.PomeriumDesktop"
+$script:ChocolateyPackageId = "pomerium-desktop"
+$script:IsElevated = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+$script:SkipReason = $null
+
+New-Item -ItemType Directory -Force -Path $script:EvidenceDirectory | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $script:EvidenceDirectory "logs") | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $script:EvidenceDirectory "generated") | Out-Null
+
+function Add-Assertion {
+  param(
+    [Parameter(Mandatory = $true)][string]$Name,
+    [Parameter(Mandatory = $true)][bool]$Passed,
+    [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Details
+  )
+
+  $script:Assertions.Add([ordered]@{
+      name = $Name
+      passed = $Passed
+      details = $Details
+      time = [DateTime]::UtcNow.ToString("o")
+    })
+
+  if (-not $Passed) {
+    throw "assertion failed: ${Name}: ${Details}"
+  }
+}
+
+function Invoke-EvidenceCommand {
+  param(
+    [Parameter(Mandatory = $true)][string]$Name,
+    [Parameter(Mandatory = $true)][string]$FilePath,
+    [Parameter(Mandatory = $true)][string[]]$ArgumentList,
+    [switch]$AllowFailure,
+    # Commands that pull the installer from GitHub releases; that endpoint returns intermittent
+    # 503s from hosted runners, so give them more than one chance before failing the run.
+    [int]$RetryCount = 0,
+    # For a command that is meant to fail, a failed download looks the same as the failure under
+    # test. Retry until the output shows the real verdict rather than accepting any failure.
+    [string]$RetryUntilOutputMatches = ""
+  )
+
+  $logPath = Join-Path $script:EvidenceDirectory "logs\${Name}.log"
+  "command: $FilePath $($ArgumentList -join ' ')" | Set-Content -Encoding utf8 $logPath
+  $startedAt = [DateTime]::UtcNow
+
+  for ($attempt = 1; ; $attempt++) {
+    "attempt ${attempt}:" | Out-File -Encoding utf8 -Append $logPath
+    $output = @(& $FilePath @ArgumentList 2>&1)
+    $exitCode = $LASTEXITCODE
+    $output | Out-File -Encoding utf8 -Append $logPath
+    "exit code: $exitCode" | Out-File -Encoding utf8 -Append $logPath
+
+    $satisfied = if ($RetryUntilOutputMatches) {
+      (@($output) -join "`n") -imatch $RetryUntilOutputMatches
+    } else {
+      $exitCode -eq 0
+    }
+    if ($satisfied -or $attempt -gt $RetryCount) {
+      break
+    }
+    Start-Sleep -Seconds (15 * $attempt)
+  }
+
+  $script:Commands.Add([ordered]@{
+      name = $Name
+      file = $FilePath
+      arguments = $ArgumentList
+      exitCode = $exitCode
+      attempts = $attempt
+      log = $logPath
+      startedAt = $startedAt.ToString("o")
+      finishedAt = [DateTime]::UtcNow.ToString("o")
+    })
+
+  if ($exitCode -ne 0 -and -not $AllowFailure) {
+    throw "command failed with exit code ${exitCode} after ${attempt} attempt(s): ${Name}. See ${logPath}."
+  }
+  return [ordered]@{ exitCode = $exitCode; output = @($output | ForEach-Object { $_.ToString() }) }
+}
+
+function Get-WinGetManifestDirectory {
+  param([Parameter(Mandatory = $true)][string]$MetadataRoot)
+
+  $manifest = @(Get-ChildItem -Path (Join-Path $MetadataRoot "winget\manifests") -Filter "*.installer.yaml" -File -Recurse)
+  Add-Assertion "one WinGet installer manifest" ($manifest.Count -eq 1) "found $($manifest.Count) installer manifests under $MetadataRoot"
+  return $manifest[0].Directory.FullName
+}
+
+function Get-ReleaseDescriptor {
+  param([Parameter(Mandatory = $true)][string]$MetadataRoot)
+
+  $descriptorPath = Join-Path $MetadataRoot "release.json"
+  Add-Assertion "release descriptor exists" (Test-Path -LiteralPath $descriptorPath -PathType Leaf) $descriptorPath
+  $release = Get-Content -Raw $descriptorPath | ConvertFrom-Json
+  return [ordered]@{
+    version = [string]$release.version
+    url = [string]$release.installerUrl
+    sha256 = ([string]$release.installerSha256).ToUpperInvariant()
+    metadataRoot = [System.IO.Path]::GetFullPath($MetadataRoot)
+  }
+}
+
+# Both package managers download the installer themselves. Probe the asset first so a runner
+# that cannot reach GitHub is not reported as a broken package.
+function Assert-InstallerReachable {
+  param([Parameter(Mandatory = $true)][object]$Descriptor)
+
+  for ($attempt = 1; $attempt -le 5; $attempt++) {
+    try {
+      $status = (Invoke-WebRequest -Uri $Descriptor.url -Method Head -MaximumRedirection 5).StatusCode
+    } catch {
+      $status = "request failed: $($_.Exception.Message)"
+    }
+    if ($status -eq 200) {
+      break
+    }
+    Start-Sleep -Seconds (10 * $attempt)
+  }
+  Add-Assertion "installer $($Descriptor.version) is reachable" ($status -eq 200) "$($Descriptor.url) returned ${status} after ${attempt} attempt(s)"
+}
+
+# A partially written or partially removed uninstall key can be missing any value, and
+# Set-StrictMode turns a direct property read on one into a terminating error.
+function Get-RegistryValue {
+  param(
+    [Parameter(Mandatory = $true)][AllowNull()][object]$Entry,
+    [Parameter(Mandatory = $true)][string]$Name
+  )
+
+  if ($null -eq $Entry -or $Entry.PSObject.Properties.Name -notcontains $Name) {
+    return $null
+  }
+  return $Entry.$Name
+}
+
+function Get-ArpState {
+  $locations = @(
+    [ordered]@{ scope = "user"; path = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\$($script:ProductCode)" },
+    [ordered]@{ scope = "machine"; path = "HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\$($script:ProductCode)" },
+    [ordered]@{ scope = "machine32"; path = "HKLM:\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\$($script:ProductCode)" }
+  )
+
+  return @($locations | ForEach-Object {
+      if (Test-Path $_.path) {
+        $entry = Get-ItemProperty $_.path
+        [ordered]@{
+          scope = $_.scope
+          registryPath = $_.path
+          displayName = Get-RegistryValue $entry "DisplayName"
+          displayVersion = Get-RegistryValue $entry "DisplayVersion"
+          publisher = Get-RegistryValue $entry "Publisher"
+          uninstallString = Get-RegistryValue $entry "UninstallString"
+          quietUninstallString = Get-RegistryValue $entry "QuietUninstallString"
+        }
+      }
+    })
+}
+
+# The NSIS installer records the install directory on its own key, not on the uninstall key.
+function Get-InstallLocation {
+  $path = "HKCU:\Software\$($script:ProductCode)"
+  if (-not (Test-Path $path)) {
+    return $null
+  }
+  return Get-RegistryValue (Get-ItemProperty $path) "InstallLocation"
+}
+
+function Get-Shortcuts {
+  $desktop = [Environment]::GetFolderPath("Desktop")
+  $startMenu = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs"
+  $paths = @(
+    Get-ChildItem -Path $desktop -Filter "Pomerium Desktop.lnk" -File -ErrorAction SilentlyContinue
+    Get-ChildItem -Path $startMenu -Filter "Pomerium Desktop.lnk" -File -Recurse -ErrorAction SilentlyContinue
+  ) | Select-Object -ExpandProperty FullName -Unique
+  return [ordered]@{
+    desktop = Join-Path $desktop "Pomerium Desktop.lnk"
+    startMenuRoot = $startMenu
+    paths = @($paths)
+  }
+}
+
+function Save-InstalledState {
+  param(
+    [Parameter(Mandatory = $true)][string]$Name,
+    [Parameter(Mandatory = $true)][string]$ExpectedVersion
+  )
+
+  $arp = @(Get-ArpState)
+  $arp | ConvertTo-Json -Depth 6 | Set-Content -Encoding utf8 (Join-Path $script:EvidenceDirectory "${Name}-arp.json")
+  $userEntries = @($arp | Where-Object { $_.scope -eq "user" })
+  $machineEntries = @($arp | Where-Object { $_.scope -ne "user" })
+  Add-Assertion "${Name} has one user ARP entry" ($userEntries.Count -eq 1) ($arp | ConvertTo-Json -Compress)
+  Add-Assertion "${Name} has no machine ARP entry" ($machineEntries.Count -eq 0) ($arp | ConvertTo-Json -Compress)
+  $entry = $userEntries[0]
+  Add-Assertion "${Name} ARP display name" ($entry.displayName -ceq "Pomerium Desktop ${ExpectedVersion}") "got $($entry.displayName)"
+  Add-Assertion "${Name} ARP version" ($entry.displayVersion -ceq $ExpectedVersion) "expected ${ExpectedVersion}, got $($entry.displayVersion)"
+  Add-Assertion "${Name} ARP publisher" ($entry.publisher -ceq "Pomerium Inc") "got $($entry.publisher)"
+  Add-Assertion "${Name} has quiet uninstall" (-not [string]::IsNullOrWhiteSpace($entry.quietUninstallString)) "quiet uninstall is $($entry.quietUninstallString)"
+  $installLocation = Get-InstallLocation
+  Add-Assertion "${Name} install path exists" ((-not [string]::IsNullOrWhiteSpace($installLocation)) -and (Test-Path -LiteralPath $installLocation -PathType Container)) "install location is ${installLocation}"
+
+  $executable = Join-Path $installLocation "Pomerium Desktop.exe"
+  Add-Assertion "${Name} executable exists" (Test-Path -LiteralPath $executable -PathType Leaf) $executable
+  # Windows reports a four-part product version, so compare the parts the release carries.
+  $fileVersion = (Get-Item $executable).VersionInfo.ProductVersion
+  $expected = [version]$ExpectedVersion
+  $actual = [version]$fileVersion
+  $versionMatches = $actual.Major -eq $expected.Major -and $actual.Minor -eq $expected.Minor -and $actual.Build -eq $expected.Build
+  Add-Assertion "${Name} executable version" $versionMatches "expected ${ExpectedVersion}, got ${fileVersion}"
+
+  $shortcutState = Get-Shortcuts
+  $shortcuts = @($shortcutState.paths)
+  $shortcuts | ConvertTo-Json | Set-Content -Encoding utf8 (Join-Path $script:EvidenceDirectory "${Name}-shortcuts.json")
+  Add-Assertion "${Name} desktop shortcut exists" ($shortcuts -contains $shortcutState.desktop) ($shortcuts -join "; ")
+  Add-Assertion "${Name} Start menu shortcut exists" (@($shortcuts | Where-Object { $_.StartsWith($shortcutState.startMenuRoot, [StringComparison]::OrdinalIgnoreCase) }).Count -eq 1) ($shortcuts -join "; ")
+
+  return [ordered]@{ arp = $entry; installLocation = $installLocation; executable = $executable; fileVersion = $fileVersion }
+}
+
+function Assert-NotInstalled {
+  param([Parameter(Mandatory = $true)][string]$Name)
+
+  $arp = @(Get-ArpState)
+  Add-Assertion "${Name} has no ARP entry" ($arp.Count -eq 0) (ConvertTo-Json -InputObject $arp -Compress)
+  $installMetadataPath = "HKCU:\Software\$($script:ProductCode)"
+  if (Test-Path $installMetadataPath) {
+    $stale = Get-RegistryValue (Get-ItemProperty $installMetadataPath) "InstallLocation"
+    if ($stale) {
+      Add-Assertion "${Name} has no install directory" (-not (Test-Path -LiteralPath $stale)) $stale
+    }
+  }
+  Add-Assertion "${Name} has no installer metadata" (-not (Test-Path $installMetadataPath)) $installMetadataPath
+  $shortcuts = @((Get-Shortcuts).paths)
+  Add-Assertion "${Name} has no application shortcuts" ($shortcuts.Count -eq 0) ($shortcuts -join "; ")
+}
+
+function Assert-PackageManagerState {
+  param(
+    [Parameter(Mandatory = $true)][string]$Name,
+    [AllowEmptyString()][string]$ExpectedVersion = ""
+  )
+
+  if ($PackageManager -eq "Chocolatey") {
+    $identifier = $script:ChocolateyPackageId
+    $result = Invoke-EvidenceCommand "${Name}-choco-list" (Get-Command choco.exe -ErrorAction Stop).Source @("list", "--exact", $script:ChocolateyPackageId, "--limit-output")
+    $lines = @($result.output)
+    $pattern = "^$([regex]::Escape($script:ChocolateyPackageId))\|$([regex]::Escape($ExpectedVersion))$"
+  } else {
+    $identifier = $script:PackageIdentifier
+    $result = Invoke-EvidenceCommand "${Name}-winget-list" (Get-Command winget.exe -ErrorAction Stop).Source @("list", "--id", $script:PackageIdentifier, "--exact", "--scope", "user", "--disable-interactivity", "--accept-source-agreements") -AllowFailure
+    $lines = @($result.output)
+    # WinGet prints one aligned row for the package. Match the identifier and the version on that row.
+    $pattern = "^\S.*\s$([regex]::Escape($script:PackageIdentifier))\s+$([regex]::Escape($ExpectedVersion))(\s|$)"
+  }
+
+  $joined = $lines -join "`n"
+  if ($ExpectedVersion) {
+    Add-Assertion "${Name} package manager version" (@($lines | Where-Object { $_ -match $pattern }).Count -eq 1) "expected ${ExpectedVersion}; output: ${joined}"
+  } else {
+    Add-Assertion "${Name} has no package manager record" ($joined -notmatch [regex]::Escape($identifier)) $joined
+  }
+}
+
+# A failed download also exits non-zero, so a bare exit-code check would pass without the
+# package manager ever comparing a hash. Require the rejection to name the checksum.
+function Assert-ChecksumRejection {
+  param(
+    [Parameter(Mandatory = $true)][object]$Result,
+    [Parameter(Mandatory = $true)][string]$Manager,
+    [Parameter(Mandatory = $true)][string]$Term
+  )
+
+  $output = @($Result.output) -join "`n"
+  Add-Assertion "${Manager} fails on a corrupt checksum" ($Result.exitCode -ne 0) "exit code $($Result.exitCode)"
+  Add-Assertion "${Manager} rejects it for the checksum" ($output -imatch $Term) $output
+}
+
+function New-CorruptMetadata {
+  param([Parameter(Mandatory = $true)][object]$Descriptor)
+
+  $destination = Join-Path $script:EvidenceDirectory "generated\corrupt-$($Descriptor.version)"
+  Copy-Item -Path $Descriptor.metadataRoot -Destination $destination -Recurse
+  $badHash = "0" * 64
+  if ($PackageManager -eq "Chocolatey") {
+    $path = Join-Path $destination "chocolatey\tools\chocolateyInstall.ps1"
+  } else {
+    $path = (Get-ChildItem -Path (Join-Path $destination "winget\manifests") -Filter "*.installer.yaml" -File -Recurse)[0].FullName
+  }
+  $contents = Get-Content -Raw $path
+  $contents = $contents.Replace($Descriptor.sha256, $badHash).Replace($Descriptor.sha256.ToLowerInvariant(), $badHash)
+  Set-Content -Encoding utf8 -Path $path -Value $contents
+  Add-Assertion "corrupted checksum was written" ((Get-Content -Raw $path).Contains($badHash)) $path
+  return $destination
+}
+
+function Invoke-ChocolateyLifecycle {
+  param([object]$OldDescriptor, [object]$NewDescriptor, [string]$CorruptRoot)
+
+  $choco = (Get-Command choco.exe -ErrorAction Stop).Source
+  $corruptPackages = Join-Path $script:EvidenceDirectory "generated\corrupt-package"
+  $oldPackages = Join-Path $script:EvidenceDirectory "generated\old-package"
+  $newPackages = Join-Path $script:EvidenceDirectory "generated\new-package"
+  New-Item -ItemType Directory -Force -Path $corruptPackages, $oldPackages, $newPackages | Out-Null
+
+  Invoke-EvidenceCommand "choco-pack-corrupt" $choco @("pack", (Join-Path $CorruptRoot "chocolatey\pomerium-desktop.nuspec"), "--output-directory", $corruptPackages) | Out-Null
+  $corrupt = Invoke-EvidenceCommand "choco-corrupt-checksum" -RetryCount 2 -RetryUntilOutputMatches "checksum" $choco @("install", $script:ChocolateyPackageId, "--version", $OldDescriptor.version, "--source", $corruptPackages, "--yes", "--no-progress", "--limit-output") -AllowFailure
+  Assert-ChecksumRejection $corrupt "Chocolatey" "checksum"
+  Assert-NotInstalled "after Chocolatey corrupt checksum"
+  Assert-PackageManagerState "after-corrupt-checksum"
+
+  Invoke-EvidenceCommand "choco-pack-$($OldDescriptor.version)" $choco @("pack", (Join-Path $OldDescriptor.metadataRoot "chocolatey\pomerium-desktop.nuspec"), "--output-directory", $oldPackages) | Out-Null
+  Invoke-EvidenceCommand "choco-pack-$($NewDescriptor.version)" $choco @("pack", (Join-Path $NewDescriptor.metadataRoot "chocolatey\pomerium-desktop.nuspec"), "--output-directory", $newPackages) | Out-Null
+  Invoke-EvidenceCommand "choco-install-$($OldDescriptor.version)" -RetryCount 2 $choco @("install", $script:ChocolateyPackageId, "--version", $OldDescriptor.version, "--source", $oldPackages, "--yes", "--no-progress", "--limit-output") | Out-Null
+  $oldState = Save-InstalledState "installed-$($OldDescriptor.version)" $OldDescriptor.version
+  Assert-PackageManagerState "installed-$($OldDescriptor.version)" $OldDescriptor.version
+
+  Invoke-EvidenceCommand "choco-upgrade-$($NewDescriptor.version)" -RetryCount 2 $choco @("upgrade", $script:ChocolateyPackageId, "--version", $NewDescriptor.version, "--source", $newPackages, "--yes", "--no-progress", "--limit-output") | Out-Null
+  $newState = Save-InstalledState "upgraded-$($NewDescriptor.version)" $NewDescriptor.version
+  Assert-PackageManagerState "upgraded-$($NewDescriptor.version)" $NewDescriptor.version
+  return [ordered]@{ old = $oldState; new = $newState }
+}
+
+function Invoke-WinGetLifecycle {
+  param([object]$OldDescriptor, [object]$NewDescriptor, [string]$CorruptRoot)
+
+  $winget = (Get-Command winget.exe -ErrorAction Stop).Source
+  Invoke-EvidenceCommand "winget-enable-local-manifests" $winget @("settings", "--enable", "LocalManifestFiles") | Out-Null
+  $corruptManifest = Get-WinGetManifestDirectory $CorruptRoot
+  $oldManifest = Get-WinGetManifestDirectory $OldDescriptor.metadataRoot
+  $newManifest = Get-WinGetManifestDirectory $NewDescriptor.metadataRoot
+  $common = @("--silent", "--disable-interactivity", "--accept-package-agreements", "--accept-source-agreements")
+
+  Invoke-EvidenceCommand "winget-validate-$($OldDescriptor.version)" $winget @("validate", $oldManifest) | Out-Null
+  Invoke-EvidenceCommand "winget-validate-$($NewDescriptor.version)" $winget @("validate", $newManifest) | Out-Null
+
+  # WinGet elevates installers by default, and the manifest declares the per-user installer
+  # elevationProhibited, so an elevated session can only prove that WinGet honours that.
+  if ($script:IsElevated) {
+    $refused = Invoke-EvidenceCommand "winget-elevated-refusal" $winget (@("install", "--manifest", $oldManifest) + $common) -AllowFailure
+    $output = @($refused.output) -join "`n"
+    Add-Assertion "WinGet refuses to elevate a per-user installer" ($refused.exitCode -ne 0) "exit code $($refused.exitCode)"
+    Add-Assertion "WinGet names the administrator context" ($output -imatch "administrator context") $output
+    Assert-NotInstalled "after WinGet elevated refusal"
+    $script:SkipReason = "WinGet installs were skipped: this session is elevated and the per-user installer is elevationProhibited."
+    return $null
+  }
+
+  $corrupt = Invoke-EvidenceCommand "winget-corrupt-checksum" -RetryCount 2 -RetryUntilOutputMatches "hash" $winget (@("install", "--manifest", $corruptManifest) + $common) -AllowFailure
+  Assert-ChecksumRejection $corrupt "WinGet" "hash"
+  Assert-NotInstalled "after WinGet corrupt checksum"
+  Assert-PackageManagerState "after-corrupt-checksum"
+
+  Invoke-EvidenceCommand "winget-install-$($OldDescriptor.version)" -RetryCount 2 $winget (@("install", "--manifest", $oldManifest) + $common) | Out-Null
+  $oldState = Save-InstalledState "installed-$($OldDescriptor.version)" $OldDescriptor.version
+  Assert-PackageManagerState "installed-$($OldDescriptor.version)" $OldDescriptor.version
+
+  Invoke-EvidenceCommand "winget-upgrade-$($NewDescriptor.version)" -RetryCount 2 $winget (@("upgrade", "--manifest", $newManifest) + $common) | Out-Null
+  $newState = Save-InstalledState "upgraded-$($NewDescriptor.version)" $NewDescriptor.version
+  Assert-PackageManagerState "upgraded-$($NewDescriptor.version)" $NewDescriptor.version
+  return [ordered]@{ old = $oldState; new = $newState }
+}
+
+function Uninstall-PomeriumDesktop {
+  if ($PackageManager -eq "Chocolatey") {
+    $choco = (Get-Command choco.exe -ErrorAction Stop).Source
+    Invoke-EvidenceCommand "choco-uninstall" $choco @("uninstall", $script:ChocolateyPackageId, "--yes", "--no-progress", "--limit-output") | Out-Null
+  } else {
+    $winget = (Get-Command winget.exe -ErrorAction Stop).Source
+    Invoke-EvidenceCommand "winget-uninstall" $winget @("uninstall", "--id", $script:PackageIdentifier, "--exact", "--scope", "user", "--silent", "--disable-interactivity", "--accept-source-agreements") | Out-Null
+  }
+}
+
+function Assert-Uninstalled {
+  param([Parameter(Mandatory = $true)][string]$InstallLocation)
+
+  $arp = @(Get-ArpState)
+  Add-Assertion "uninstall removes ARP entry" ($arp.Count -eq 0) (ConvertTo-Json -InputObject $arp -Compress)
+  Add-Assertion "uninstall removes install directory" (-not (Test-Path -LiteralPath $InstallLocation)) $InstallLocation
+  $shortcuts = @((Get-Shortcuts).paths)
+  Add-Assertion "uninstall removes application shortcuts" ($shortcuts.Count -eq 0) ($shortcuts -join "; ")
+}
+
+# An installer that dies on an access violation reports only an exit code, so capture what
+# Windows recorded about the crash.
+function Save-CrashReports {
+  try {
+    $events = @(Get-WinEvent -FilterHashtable @{ LogName = "Application"; ProviderName = "Application Error", "Windows Error Reporting" } -MaxEvents 10 -ErrorAction Stop |
+        Select-Object TimeCreated, ProviderName, Id, Message)
+  } catch {
+    $events = @([ordered]@{ error = $_.Exception.Message })
+  }
+  $events | ConvertTo-Json -Depth 5 | Set-Content -Encoding utf8 (Join-Path $script:EvidenceDirectory "crash-reports.json")
+}
+
+function Save-Summary {
+  [ordered]@{
+    packageManager = $PackageManager
+    oldMetadataRoot = [System.IO.Path]::GetFullPath($OldMetadataRoot)
+    newMetadataRoot = [System.IO.Path]::GetFullPath($NewMetadataRoot)
+    evidenceDirectory = $script:EvidenceDirectory
+    startedAt = $script:StartedAt.ToString("o")
+    finishedAt = [DateTime]::UtcNow.ToString("o")
+    completed = $script:LifecycleCompleted
+    skipped = $script:SkipReason
+    failure = $script:Failure
+    assertions = $script:Assertions
+    commands = $script:Commands
+  } | ConvertTo-Json -Depth 10 | Set-Content -Encoding utf8 (Join-Path $script:EvidenceDirectory "summary.json")
+}
+
+Push-Location $script:RepositoryRoot
+try {
+  $oldDescriptor = Get-ReleaseDescriptor $OldMetadataRoot
+  $newDescriptor = Get-ReleaseDescriptor $NewMetadataRoot
+  Add-Assertion "upgrade path goes forward" ([version]$newDescriptor.version -gt [version]$oldDescriptor.version) "$($oldDescriptor.version) to $($newDescriptor.version)"
+  Assert-InstallerReachable $oldDescriptor
+  Assert-InstallerReachable $newDescriptor
+  Assert-NotInstalled "initial state"
+  $corruptRoot = New-CorruptMetadata $oldDescriptor
+
+  if ($PackageManager -eq "Chocolatey") {
+    $state = Invoke-ChocolateyLifecycle $oldDescriptor $newDescriptor $corruptRoot
+  } else {
+    $state = Invoke-WinGetLifecycle $oldDescriptor $newDescriptor $corruptRoot
+  }
+
+  if ($null -ne $state) {
+    $installLocation = $state.new.installLocation
+    Uninstall-PomeriumDesktop
+    Assert-Uninstalled $installLocation
+    Assert-PackageManagerState "after-uninstall"
+  }
+  $script:LifecycleCompleted = $true
+} catch {
+  $script:Failure = $_.Exception.ToString()
+  Save-CrashReports
+  throw
+} finally {
+  Save-Summary
+  Pop-Location
+}
+
+# Commands that are expected to fail leave their code in $LASTEXITCODE, and the calling shell
+# would exit with it, so report the lifecycle result rather than the last command's.
+exit 0


### PR DESCRIPTION
## Summary

Windows users have to download Pomerium Desktop from GitHub by hand and watch this repository for new releases, so they cannot fold the client into the Chocolatey or WinGet automation they already run for the rest of their fleet.

This adds a generator that turns one exact stable release tag into both catalog formats. It reads the GitHub release once, refuses anything that is not a published stable tag with exactly one fully uploaded installer asset carrying a SHA-256 digest at the canonical download URL, and writes the verified descriptor beside the generated files. Both renderers are pure functions of that descriptor, so the Chocolatey package and the WinGet manifests can never disagree about a version, URL, or checksum. The generated files for v0.33.0 are checked in as golden fixtures, which makes the catalog text itself reviewable in a diff.

A validation workflow proves the result on windows-2025. The Chocolatey job runs the whole lifecycle: it rejects a corrupted checksum and leaves no trace, installs v0.32.2 silently, upgrades to v0.33.0, and uninstalls, asserting at each step that exactly one current-user Apps and Features entry exists with the expected name, version, publisher and quiet uninstall string, that the install directory and executable match the release, that both shortcuts exist, and that uninstall removes all of it. That job runs 43 assertions.

The WinGet manifests declare `ElevationRequirement: elevationProhibited`. Running this per-user NSIS installer elevated crashes it, and WinGet elevates installers by default, so without that field `winget install` from an administrator console dies with an access violation inside NSIS rather than reporting anything useful. GitHub-hosted runners are themselves elevated, so the WinGet job proves what an elevated session can: all three manifests validate, and WinGet refuses the install with "the installer cannot be run from an administrator context" and leaves no residue. The harness runs the same full install, upgrade and uninstall lifecycle as Chocolatey when it is given a non-elevated session, and it records the skip and its reason in the evidence rather than passing silently. Closing that gap needs a non-elevated Windows runner and is worth deciding separately.

The manifests target ManifestVersion 1.10.0. `winget validate` checks the schema header against the `$id` of the schema file that the installed client carries, so a manifest declaring a newer version than the shipping client warns and exits non-zero.

The `license` field in package.json said MIT while LICENSE has always been Apache 2.0. The generated WinGet locale manifest has to declare a license, so this corrects the field rather than publishing a claim that contradicts the repository.

This PR wraps the existing unsigned x64 per-user NSIS installer. It publishes nothing, adds no catalog credentials, and does not change the installer or the release process. The first submission to each catalog is a separate, separately approved step.

`npm run format:check`, `npm run lint` and `npm test` pass locally; generating v0.33.0 against the live GitHub API reproduces the checked-in golden files byte for byte; and all three manifests validate against the official 1.10.0 JSON schemas. Both Windows jobs pass, and each uploads its logs, registry snapshots and machine-readable assertion summary.

This change was implemented with AI assistance.

## Related issues

- [ENG-4284: Feature Request: Chocolatey / Winget Installation](https://linear.app/pomerium/issue/ENG-4284/feature-request-chocolatey-winget-installation)

## Checklist

- [x] reference any related issues
- [x] updated docs
- [x] updated unit tests
- [x] updated UPGRADING.md (not required; installer and upgrade behavior do not change)
- [x] add appropriate tag (`improvement`)
- [ ] ready for review
